### PR TITLE
Fix: Assignments without outgoing labels caused error

### DIFF
--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
@@ -287,8 +287,8 @@ public class WebEditorConverter extends Converter{
                 assignment.setOutputPin(outpin);
                 assignment.setTerm(behaviorConverter.stringToTerm(term));
                 assignment.getInputPins().addAll(getInPinsFromString(inPinsAsString, node, dfd));
-                
                 Arrays.asList(outLabelsAsString.split(",")).forEach(typeValuePair -> {
+                	if (typeValuePair == null || typeValuePair.trim().equals("")) return;
                      String typeName = typeValuePair.split("\\.")[0];
                      String valueName = typeValuePair.split("\\.")[1];
                      

--- a/tests/org.dataflowanalysis.converter.tests/models/ConverterTest/minimal.json
+++ b/tests/org.dataflowanalysis.converter.tests/models/ConverterTest/minimal.json
@@ -26,20 +26,24 @@
     }, {
       "text" : "encrypt",
       "labels" : [ ],
-      "ports" : [ {
-        "behavior" : "Forwarding({data})\nAssignment({};TRUE;{Encryption.Encrypted})",
-        "id" : "3wntc",
-        "type" : "port:dfd-output",
-        "children" : [ ]
-      }, {
-        "id" : "kqjy4g",
-        "type" : "port:dfd-input",
-        "children" : [ ]
-      }, {
-        "id" : "mvakn",
-        "type" : "port:dfd-output",
-        "children" : [ ]
-      } ],
+      "ports": [
+        {
+          "behavior": "Forwarding({data})\nAssignment({};TRUE;{Encryption.Encrypted})\nAssignment({};TRUE;{})",
+          "id": "3wntc",
+          "type": "port:dfd-output",
+          "children": []
+        },
+        {
+          "id": "kqjy4g",
+          "type": "port:dfd-input",
+          "children": []
+        },
+        {
+          "id": "mvakn",
+          "type": "port:dfd-output",
+          "children": []
+        }
+      ],
       "id" : "3n988k",
       "type" : "node:function",
       "annotation" : {


### PR DESCRIPTION
Assignments without outgoing labels (necessary for preserving control flow) cause an IndexOutOfBoundsException