### PR TITLE
Allow assignments in pcm to reference non-existing dfd pins

### DIFF
--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/PCMConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/PCMConverter.java
@@ -673,11 +673,13 @@ public class PCMConverter extends Converter {
 		Pin outPin = node.getBehavior().getOutPin().stream()
 				.filter(it -> it.getEntityName().equals(reference.getReferenceName())).findAny().orElseThrow();
 		assignment.setOutputPin(outPin);
-		Pin inPin = node.getBehavior().getInPin().stream().filter(
+		Optional<Pin> inPin = node.getBehavior().getInPin().stream().filter(
 				it -> it.getEntityName().equals(namedEnumCharacteristicReference.getNamedReference().getReferenceName())
 						|| it.getEntityName().equals(""))
-				.findAny().orElseThrow();
-		assignment.getInputPins().add(inPin);
+				.findAny();
+		if (inPin.isPresent()) {
+			assignment.getInputPins().add(inPin.get());
+		}
 		return assignment;
 	}
 

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/PCMConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/PCMConverter.java
@@ -679,6 +679,8 @@ public class PCMConverter extends Converter {
 				.findAny();
 		if (inPin.isPresent()) {
 			assignment.getInputPins().add(inPin.get());
+		} else {
+			logger.warn("One StoEx references incoming data that is not incoming!");
 		}
 		return assignment;
 	}


### PR DESCRIPTION
Some assignments for PCM elements might reference a data flow variable that is not incoming (so it has no corresponding pin). 

We should not fail hard, instead return an assignment without referencing the input pin. Existing behavior is not changed