### PR TITLE
Enforce formatting pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
           maven-version: 3.9.6
       - name: Build and Verify
         run: mvn clean verify
+      - name: Check formatting
+        run: mvn spotless:check
       - name: Publish Nightly Update Site
         if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'DataFlowAnalysis'
         uses: peaceiris/actions-gh-pages@v4

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/BehaviorConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/BehaviorConverter.java
@@ -163,8 +163,8 @@ public class BehaviorConverter {
 
     private String termToString(Term term, boolean isNested) {
         if (term instanceof LabelReference labelReference) {
-        	Label label = labelReference.getLabel();
-            return ((LabelType)label.eContainer()).getEntityName() + "." + label.getEntityName();
+            Label label = labelReference.getLabel();
+            return ((LabelType) label.eContainer()).getEntityName() + "." + label.getEntityName();
         } else if (term instanceof TRUE) {
             return "TRUE";
         } else if (term instanceof AND and) {

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/Converter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/Converter.java
@@ -1,10 +1,6 @@
 package org.dataflowanalysis.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
-import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -17,6 +13,8 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.XMLResourceFactoryImpl;
+import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
+import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder;
 
 public abstract class Converter {
     protected ObjectMapper objectMapper;
@@ -27,7 +25,7 @@ public abstract class Converter {
     public Converter() {
         objectMapper = new ObjectMapper();
     }
-    
+
     /**
      * Loads a data flow diagram and data dictionary from specified input files and returns them as a combined object.
      * @param inputDataFlowDiagram The path of the input data flow diagram file.

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/DataFlowDiagramConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/DataFlowDiagramConverter.java
@@ -104,21 +104,23 @@ public class DataFlowDiagramConverter extends Converter {
             Class<?> activator, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass)
             throws StandaloneInitializationException {
         DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);
-        
+
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, finderClass), false);
     }
-    
+
     /**
-     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it with a custom Finder, checks for the constraints and annotates the WebDFD. Also sets the readonly flag
+     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it with a
+     * custom Finder, checks for the constraints and annotates the WebDFD. Also sets the readonly flag
      * @param inputDataFlowDiagram The path of the data flow diagram.
      * @param inputDataDictionary The path of the data dictionary.
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      * @throws StandaloneInitializationException
      */
-    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinderAndSetReadOnly(String project, String inputDataFlowDiagram, String inputDataDictionary, Class<?> activator, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass)
-            throws StandaloneInitializationException {
-        DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);       
-        
+    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinderAndSetReadOnly(String project, String inputDataFlowDiagram,
+            String inputDataDictionary, Class<?> activator, List<Predicate<? super AbstractVertex<?>>> conditions,
+            Class<? extends TransposeFlowGraphFinder> finderClass) throws StandaloneInitializationException {
+        DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);
+
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, finderClass), true);
     }
 
@@ -134,18 +136,21 @@ public class DataFlowDiagramConverter extends Converter {
      * @param finderClass Custom TFG Finder
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      */
-    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinder(DataFlowDiagramAndDictionary complete, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
+    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinder(DataFlowDiagramAndDictionary complete,
+            List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, finderClass), false);
     }
-    
+
     /**
-     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it with a custom Finder, checks for the constraints and annotates the WebDFD. Also sets the readonly flag
+     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it with a custom Finder, checks
+     * for the constraints and annotates the WebDFD. Also sets the readonly flag
      * @param complete The DataFlowDiagramAndDictionary object to convert.
      * @param conditions List of constraints
      * @param finderClass Custom TFG Finder
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      */
-    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinderAndSetReadOnly(DataFlowDiagramAndDictionary complete, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
+    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinderAndSetReadOnly(DataFlowDiagramAndDictionary complete,
+            List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, finderClass), true);
     }
 
@@ -259,7 +264,8 @@ public class DataFlowDiagramConverter extends Converter {
         }
     }
 
-    private WebEditorDfd processDfd(DataFlowDiagram dataFlowDiagram, DataDictionary dataDictionary, Map<Node, Annotation> mapNodeToAnnotation, boolean readOnly) {
+    private WebEditorDfd processDfd(DataFlowDiagram dataFlowDiagram, DataDictionary dataDictionary, Map<Node, Annotation> mapNodeToAnnotation,
+            boolean readOnly) {
         inputPinToFlowNamesMap = new HashMap<>();
         List<Child> children = new ArrayList<>();
         List<WebEditorLabelType> labelTypes = new ArrayList<>();

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/DataFlowDiagramConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/DataFlowDiagramConverter.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.converter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,7 +33,7 @@ import tools.mdsd.library.standalone.initialization.StandaloneInitializationExce
  */
 public class DataFlowDiagramConverter extends Converter {
 
-	private Map<Pin, List<String>> inputPinToFlowNamesMap;
+    private Map<Pin, List<String>> inputPinToFlowNamesMap;
 
     private final Logger logger = Logger.getLogger(DataFlowDiagramConverter.class);
     protected final static String DELIMITER_PIN_NAME = "|";
@@ -45,7 +44,8 @@ public class DataFlowDiagramConverter extends Converter {
     private BehaviorConverter behaviorConverter;
 
     /**
-     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it and annotates the propagated labels in the WebDFD.
+     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it and
+     * annotates the propagated labels in the WebDFD.
      * @param inputDataFlowDiagram The path of the data flow diagram.
      * @param inputDataDictionary The path of the data dictionary.
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
@@ -58,47 +58,52 @@ public class DataFlowDiagramConverter extends Converter {
     }
 
     /**
-     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it and annotates the propagated labels in the WebDFD.
+     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it and annotates the propagated
+     * labels in the WebDFD.
      * @param complete The DataFlowDiagramAndDictionary object to convert.
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      */
     public WebEditorDfd dfdToWeb(DataFlowDiagramAndDictionary complete) {
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, null, null), false);
     }
-    
+
     /**
-     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it, checks for the constraints and annotates the WebDFD.
+     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it, checks for
+     * the constraints and annotates the WebDFD.
      * @param inputDataFlowDiagram The path of the data flow diagram.
      * @param inputDataDictionary The path of the data dictionary.
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      * @throws StandaloneInitializationException
      */
-    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotate(String project, String inputDataFlowDiagram, String inputDataDictionary, Class<?> activator, List<Predicate<? super AbstractVertex<?>>> conditions)
-            throws StandaloneInitializationException {
-        DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);       
-        
+    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotate(String project, String inputDataFlowDiagram, String inputDataDictionary, Class<?> activator,
+            List<Predicate<? super AbstractVertex<?>>> conditions) throws StandaloneInitializationException {
+        DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);
+
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, null), false);
     }
 
     /**
-     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it, checks for the constraints and annotates the WebDFD.
+     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it, checks for the constraints
+     * and annotates the WebDFD.
      * @param complete The DataFlowDiagramAndDictionary object to convert.
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      */
     public WebEditorDfd dfdToWebAndAnalyzeAndAnnotate(DataFlowDiagramAndDictionary complete, List<Predicate<? super AbstractVertex<?>>> conditions) {
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, null), false);
     }
-    
+
     /**
-     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it with a custom Finder, checks for the constraints and annotates the WebDFD.
+     * Converts Data Flow Diagram and Data Dictionary provided via paths into a WebEditorDfd object, analyzes it with a
+     * custom Finder, checks for the constraints and annotates the WebDFD.
      * @param inputDataFlowDiagram The path of the data flow diagram.
      * @param inputDataDictionary The path of the data dictionary.
      * @return WebEditorDfd object representing the web editor version of the data flow diagram.
      * @throws StandaloneInitializationException
      */
-    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinder(String project, String inputDataFlowDiagram, String inputDataDictionary, Class<?> activator, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass)
+    public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinder(String project, String inputDataFlowDiagram, String inputDataDictionary,
+            Class<?> activator, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass)
             throws StandaloneInitializationException {
-        DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);       
+        DataFlowDiagramAndDictionary complete = loadDFD(project, inputDataFlowDiagram, inputDataDictionary, activator);
         
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, finderClass), false);
     }
@@ -122,7 +127,8 @@ public class DataFlowDiagramConverter extends Converter {
     }
 
     /**
-     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it with a custom Finder, checks for the constraints and annotates the WebDFD.
+     * Converts a DataFlowDiagramAndDictionary object into a WebEditorDfd object, analyzes it with a custom Finder, checks
+     * for the constraints and annotates the WebDFD.
      * @param complete The DataFlowDiagramAndDictionary object to convert.
      * @param conditions List of constraints
      * @param finderClass Custom TFG Finder
@@ -142,7 +148,7 @@ public class DataFlowDiagramConverter extends Converter {
     public WebEditorDfd dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinderAndSetReadOnly(DataFlowDiagramAndDictionary complete, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
         return processDfd(complete.dataFlowDiagram(), complete.dataDictionary(), createNodeAnnotationMap(complete, conditions, finderClass), true);
     }
-    
+
     /**
      * Stores a WebEditorDfd object into a specified output file.
      * @param web The WebEditorDfd object to store.
@@ -158,7 +164,7 @@ public class DataFlowDiagramConverter extends Converter {
         } catch (IOException e) {
             logger.error("Could not store web dfd:", e);
         }
-    }   
+    }
 
     /**
      * Creates the node annotations by analyzing the DFD
@@ -167,62 +173,81 @@ public class DataFlowDiagramConverter extends Converter {
      * @param finderClass Custom TFG Finder (optional)
      * @return
      */
-    private Map<Node, Annotation> createNodeAnnotationMap (DataFlowDiagramAndDictionary complete, List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
-    	TransposeFlowGraphFinder finder;
-    	if (finderClass == null) finder = new DFDTransposeFlowGraphFinder(complete.dataDictionary(), complete.dataFlowDiagram());
-    	else {
-    		if (finderClass.equals(DFDSimpleTransposeFlowGraphFinder.class))
-            	finder = new DFDSimpleTransposeFlowGraphFinder(complete.dataDictionary(), complete.dataFlowDiagram());
+    private Map<Node, Annotation> createNodeAnnotationMap(DataFlowDiagramAndDictionary complete,
+            List<Predicate<? super AbstractVertex<?>>> conditions, Class<? extends TransposeFlowGraphFinder> finderClass) {
+        TransposeFlowGraphFinder finder;
+        if (finderClass == null)
+            finder = new DFDTransposeFlowGraphFinder(complete.dataDictionary(), complete.dataFlowDiagram());
+        else {
+            if (finderClass.equals(DFDSimpleTransposeFlowGraphFinder.class))
+                finder = new DFDSimpleTransposeFlowGraphFinder(complete.dataDictionary(), complete.dataFlowDiagram());
             else
                 finder = new DFDTransposeFlowGraphFinder(complete.dataDictionary(), complete.dataFlowDiagram());
-    			 
-    	}
-         var collection = finder.findTransposeFlowGraphs();
-         collection = collection.stream().map(AbstractTransposeFlowGraph::evaluate).toList();
-         
-         Map<Node, Annotation> mapNodeToAnnotations = new HashMap<>();
-         Map<Node, Set<String>> mapNodeToPropagatedLabels = new HashMap<>();
-         collection.stream().forEach(tfg -> tfg.getVertices().forEach(vertex -> {
-         	Node node = (Node) vertex.getReferencedElement();        	
-         	mapNodeToPropagatedLabels.putIfAbsent(node, new HashSet<>());
-         	var label = mapNodeToPropagatedLabels.get(node);
-         	vertex.getAllOutgoingDataCharacteristics().forEach(characteristic -> characteristic.getAllCharacteristics().forEach(value -> {
-         		label.add(value.getTypeName() + "." + value.getValueName());
-         	}));         	
-         }));
-         
-         mapNodeToPropagatedLabels.keySet().forEach(key -> {
-        	StringBuilder builder = new StringBuilder();
-	      	builder.append("PropagatedLabels:").append("\n");
-	      	
-	      	mapNodeToPropagatedLabels.get(key).forEach(value -> {
-	      		builder.append(value).append("\n");
-	      	});
-	      	if (!mapNodeToPropagatedLabels.get(key).isEmpty())mapNodeToAnnotations.put(key, new Annotation(builder.toString(), "tag", "#FFFFFF"));
-        });
-        
-         
-         if (conditions == null) return mapNodeToAnnotations;
-         
-         DFDConfidentialityAnalysis analysis = new DFDConfidentialityAnalysis(null, null, null);
-         for (int i = 0; i < conditions.size(); i++) {
-         	var condition = conditions.get(i);
-         	if (condition == null) continue;
-         	for (var tfg : collection) {         		
-         		var violations = analysis.queryDataFlow(tfg, condition);
-         		for (var vertex : violations) {
-         			Node node = (Node)vertex.getReferencedElement();   	
-                 	StringBuilder builder = new StringBuilder();
-                 	if (mapNodeToAnnotations.get(node) != null) builder.append(mapNodeToAnnotations.get(node).message()).append("\n");
-                 	builder.append("Violation: Constraint ").append(i).append(" violated.").append("\n");
-                 	mapNodeToAnnotations.put(node, new Annotation(builder.toString(), "bolt", "#ff0000"));
-         		}
-         	}
-         }
-         return mapNodeToAnnotations;
+
+        }
+        var collection = finder.findTransposeFlowGraphs();
+        collection = collection.stream()
+                .map(AbstractTransposeFlowGraph::evaluate)
+                .toList();
+
+        Map<Node, Annotation> mapNodeToAnnotations = new HashMap<>();
+        Map<Node, Set<String>> mapNodeToPropagatedLabels = new HashMap<>();
+        collection.stream()
+                .forEach(tfg -> tfg.getVertices()
+                        .forEach(vertex -> {
+                            Node node = (Node) vertex.getReferencedElement();
+                            mapNodeToPropagatedLabels.putIfAbsent(node, new HashSet<>());
+                            var label = mapNodeToPropagatedLabels.get(node);
+                            vertex.getAllOutgoingDataCharacteristics()
+                                    .forEach(characteristic -> characteristic.getAllCharacteristics()
+                                            .forEach(value -> {
+                                                label.add(value.getTypeName() + "." + value.getValueName());
+                                            }));
+                        }));
+
+        mapNodeToPropagatedLabels.keySet()
+                .forEach(key -> {
+                    StringBuilder builder = new StringBuilder();
+                    builder.append("PropagatedLabels:")
+                            .append("\n");
+
+                    mapNodeToPropagatedLabels.get(key)
+                            .forEach(value -> {
+                                builder.append(value)
+                                        .append("\n");
+                            });
+                    if (!mapNodeToPropagatedLabels.get(key)
+                            .isEmpty())
+                        mapNodeToAnnotations.put(key, new Annotation(builder.toString(), "tag", "#FFFFFF"));
+                });
+
+        if (conditions == null)
+            return mapNodeToAnnotations;
+
+        DFDConfidentialityAnalysis analysis = new DFDConfidentialityAnalysis(null, null, null);
+        for (int i = 0; i < conditions.size(); i++) {
+            var condition = conditions.get(i);
+            if (condition == null)
+                continue;
+            for (var tfg : collection) {
+                var violations = analysis.queryDataFlow(tfg, condition);
+                for (var vertex : violations) {
+                    Node node = (Node) vertex.getReferencedElement();
+                    StringBuilder builder = new StringBuilder();
+                    if (mapNodeToAnnotations.get(node) != null)
+                        builder.append(mapNodeToAnnotations.get(node)
+                                .message())
+                                .append("\n");
+                    builder.append("Violation: Constraint ")
+                            .append(i)
+                            .append(" violated.")
+                            .append("\n");
+                    mapNodeToAnnotations.put(node, new Annotation(builder.toString(), "bolt", "#ff0000"));
+                }
+            }
+        }
+        return mapNodeToAnnotations;
     }
-
-
 
     private void createLabelTypesAndValues(List<WebEditorLabelType> labelTypes, DataDictionary dataDictionary) {
         for (LabelType labelType : dataDictionary.getLabelTypes()) {
@@ -237,7 +262,7 @@ public class DataFlowDiagramConverter extends Converter {
     private WebEditorDfd processDfd(DataFlowDiagram dataFlowDiagram, DataDictionary dataDictionary, Map<Node, Annotation> mapNodeToAnnotation, boolean readOnly) {
         inputPinToFlowNamesMap = new HashMap<>();
         List<Child> children = new ArrayList<>();
-        List<WebEditorLabelType> labelTypes = new ArrayList<>();        
+        List<WebEditorLabelType> labelTypes = new ArrayList<>();
 
         behaviorConverter = new BehaviorConverter(dataDictionary);
 
@@ -287,34 +312,39 @@ public class DataFlowDiagramConverter extends Converter {
                     .forEach(pin -> ports
                             .add(new Port(createBehaviorString(mapPinToAssignments.get(pin)), pin.getId(), "port:dfd-output", new ArrayList<>())));
             if (mapNodeToAnnotation == null)
-            	children.add(new Child(text, labels, ports, id, type, null, null, null, new ArrayList<>()));
-            else 
-            	children.add(new Child(text, labels, ports, id, type, null, null, mapNodeToAnnotation.get(node), new ArrayList<>()));
+                children.add(new Child(text, labels, ports, id, type, null, null, null, new ArrayList<>()));
+            else
+                children.add(new Child(text, labels, ports, id, type, null, null, mapNodeToAnnotation.get(node), new ArrayList<>()));
         }
     }
 
     private void createFlows(DataFlowDiagram dataFlowDiagram, List<Child> children) {
-    	var controlFlowNameMap = createControlFlowNameMap(dataFlowDiagram);
+        var controlFlowNameMap = createControlFlowNameMap(dataFlowDiagram);
         for (Flow flow : dataFlowDiagram.getFlows()) {
-        	fillPinToFlowNamesMap(inputPinToFlowNamesMap,flow, controlFlowNameMap);
+            fillPinToFlowNamesMap(inputPinToFlowNamesMap, flow, controlFlowNameMap);
             children.add(createFlow(flow, controlFlowNameMap));
         }
     }
-    
+
     private HashMap<Flow, String> createControlFlowNameMap(DataFlowDiagram dataFlowDiagram) {
-    	var controlFlowNameMap = new HashMap<Flow, String>();
-    	dataFlowDiagram.getNodes().forEach(node -> {
-    		var controlFlows = dataFlowDiagram.getFlows().stream()
-	    		.filter(flow -> flow.getDestinationNode().equals(node))
-	    		.filter(flow -> flow.getEntityName().equals("")).toList();
-    		
-    		String controlFlowName = CONTROL_FLOW_NAME;
-    		for (var flow : controlFlows) {
-    			controlFlowNameMap.put(flow, controlFlowName);
-    			controlFlowName += CONTROL_FLOW_NAME;
-    		}
-    	});
-    	return controlFlowNameMap;
+        var controlFlowNameMap = new HashMap<Flow, String>();
+        dataFlowDiagram.getNodes()
+                .forEach(node -> {
+                    var controlFlows = dataFlowDiagram.getFlows()
+                            .stream()
+                            .filter(flow -> flow.getDestinationNode()
+                                    .equals(node))
+                            .filter(flow -> flow.getEntityName()
+                                    .equals(""))
+                            .toList();
+
+                    String controlFlowName = CONTROL_FLOW_NAME;
+                    for (var flow : controlFlows) {
+                        controlFlowNameMap.put(flow, controlFlowName);
+                        controlFlowName += CONTROL_FLOW_NAME;
+                    }
+                });
+        return controlFlowNameMap;
     }
 
     private Child createFlow(Flow flow, HashMap<Flow, String> controlFlowNameMap) {
@@ -323,11 +353,10 @@ public class DataFlowDiagramConverter extends Converter {
         String sourceId = flow.getSourcePin()
                 .getId();
         String targetId = flow.getDestinationPin()
-                .getId(); 
+                .getId();
         String text = controlFlowNameMap.getOrDefault(flow, flow.getEntityName());
         return new Child(text, null, null, id, type, sourceId, targetId, null, new ArrayList<>());
     }
-    
 
     private Map<Pin, List<AbstractAssignment>> mapping(Node node) {
         Map<Pin, List<AbstractAssignment>> mapPinToAssignments = new HashMap<>();
@@ -353,35 +382,36 @@ public class DataFlowDiagramConverter extends Converter {
         StringBuilder builder = new StringBuilder();
         for (AbstractAssignment abstractAssignment : abstractAssignments) {
             if (abstractAssignment instanceof ForwardingAssignment forwardingAssignment) {
-                builder.append("forward ");                
+                builder.append("forward ");
                 builder.append(getStringFromInputPins(forwardingAssignment.getInputPins()));
             } else if (abstractAssignment instanceof SetAssignment setAssignment) {
-            	builder.append("set ");
-            	builder.append(getStringFromOutLabels(setAssignment.getOutputLabels()));
+                builder.append("set ");
+                builder.append(getStringFromOutLabels(setAssignment.getOutputLabels()));
             } else if (abstractAssignment instanceof UnsetAssignment unsetAssignment) {
-            	builder.append("unset ");
-            	builder.append(getStringFromOutLabels(unsetAssignment.getOutputLabels()));
-            } else if (abstractAssignment instanceof Assignment assignment) {                
+                builder.append("unset ");
+                builder.append(getStringFromOutLabels(unsetAssignment.getOutputLabels()));
+            } else if (abstractAssignment instanceof Assignment assignment) {
                 builder.append("assign ");
                 builder.append(getStringFromOutLabels(assignment.getOutputLabels()));
                 builder.append(" if ");
                 builder.append(behaviorConverter.termToString(assignment.getTerm()));
-                if (!assignment.getInputPins().isEmpty()) {
-                	builder.append(" from ");
-                	builder.append(getStringFromInputPins(assignment.getInputPins()));
-                }      
+                if (!assignment.getInputPins()
+                        .isEmpty()) {
+                    builder.append(" from ");
+                    builder.append(getStringFromInputPins(assignment.getInputPins()));
+                }
             }
             builder.append("\n");
         }
         return builder.toString()
                 .trim();
     }
-    
-    private String getStringFromInputPins (List<Pin> inputPins) {
-    	List<String> pinNamesAsString = new ArrayList<>();
-        
-    	inputPins.forEach(pin -> {
-        	var flowNames = inputPinToFlowNamesMap.get(pin)
+
+    private String getStringFromInputPins(List<Pin> inputPins) {
+        List<String> pinNamesAsString = new ArrayList<>();
+
+        inputPins.forEach(pin -> {
+            var flowNames = inputPinToFlowNamesMap.get(pin)
                     .stream()
                     .sorted()
                     .toList();
@@ -390,18 +420,18 @@ public class DataFlowDiagramConverter extends Converter {
         });
         return String.join(DELIMITER_MULTI_PIN, pinNamesAsString);
     }
-    
-    private String getStringFromOutLabels (List<Label> outLabels) {
-    	List<String> outLabelsAsStrings = new ArrayList<>();
-        
-    	outLabels.forEach(label -> {
-    		outLabelsAsStrings.add(((LabelType)label.eContainer()).getEntityName() + "." + label.getEntityName());
+
+    private String getStringFromOutLabels(List<Label> outLabels) {
+        List<String> outLabelsAsStrings = new ArrayList<>();
+
+        outLabels.forEach(label -> {
+            outLabelsAsStrings.add(((LabelType) label.eContainer()).getEntityName() + "." + label.getEntityName());
         });
-    	
+
         return String.join(DELIMITER_MULTI_LABEL, outLabelsAsStrings);
     }
 
-    private void fillPinToFlowNamesMap(Map<Pin,List<String>> map,Flow flow,  HashMap<Flow, String> controlFlowNameMap) {
+    private void fillPinToFlowNamesMap(Map<Pin, List<String>> map, Flow flow, HashMap<Flow, String> controlFlowNameMap) {
         if (map.containsKey(flow.getDestinationPin())) {
             map.get(flow.getDestinationPin())
                     .add(controlFlowNameMap.getOrDefault(flow, flow.getEntityName()));

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/MicroSecEndConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/MicroSecEndConverter.java
@@ -8,11 +8,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.lang.Process;
-
 import org.dataflowanalysis.converter.microsecend.*;
-import org.dataflowanalysis.dfd.datadictionary.*;
-import org.dataflowanalysis.dfd.dataflowdiagram.*;
+import org.dataflowanalysis.dfd.datadictionary.Assignment;
+import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
+import org.dataflowanalysis.dfd.datadictionary.Label;
+import org.dataflowanalysis.dfd.datadictionary.LabelType;
+import org.dataflowanalysis.dfd.datadictionary.Pin;
+import org.dataflowanalysis.dfd.datadictionary.datadictionaryFactory;
+import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
+import org.dataflowanalysis.dfd.dataflowdiagram.Node;
+import org.dataflowanalysis.dfd.dataflowdiagram.dataflowdiagramFactory;
 
 /**
  * Converts MicroSecEnd models to the data flow diagram and dictionary representation. Inherits from {@link Converter}

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/PCMConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/PCMConverter.java
@@ -1,28 +1,28 @@
 package org.dataflowanalysis.converter;
 
+import de.uka.ipd.sdq.stoex.AbstractNamedReference;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.HashSet;
-import java.util.ArrayList;
-
 import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
-import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
+import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
-import org.dataflowanalysis.analysis.pcm.core.PCMTransposeFlowGraph;
 import org.dataflowanalysis.analysis.pcm.core.seff.CallingSEFFPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.seff.SEFFPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.user.CallingUserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.user.UserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
+import org.dataflowanalysis.dfd.datadictionary.*;
 import org.dataflowanalysis.dfd.datadictionary.AbstractAssignment;
 import org.dataflowanalysis.dfd.datadictionary.Assignment;
 import org.dataflowanalysis.dfd.datadictionary.Behavior;
@@ -34,825 +34,934 @@ import org.dataflowanalysis.dfd.datadictionary.datadictionaryFactory;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
 import org.dataflowanalysis.dfd.dataflowdiagram.Node;
 import org.dataflowanalysis.dfd.dataflowdiagram.dataflowdiagramFactory;
+import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.EnumCharacteristicType;
 import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.Literal;
+import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.And;
+import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.False;
+import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.Or;
 import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.Term;
+import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.True;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.ConfidentialityVariableCharacterisation;
+import org.dataflowanalysis.pcm.extension.model.confidentiality.expression.LhsEnumCharacteristicReference;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.expression.NamedEnumCharacteristicReference;
 import org.eclipse.core.runtime.Plugin;
 import org.palladiosimulator.pcm.core.entity.Entity;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.seff.*;
+import org.palladiosimulator.pcm.seff.ExternalCallAction;
+import org.palladiosimulator.pcm.seff.SetVariableAction;
 import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
 import org.palladiosimulator.pcm.usagemodel.EntryLevelSystemCall;
 import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.Stop;
 
-import de.uka.ipd.sdq.stoex.AbstractNamedReference;
-import org.dataflowanalysis.dfd.datadictionary.*;
-import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.EnumCharacteristicType;
-import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.And;
-import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.False;
-import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.Or;
-import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.True;
-import org.dataflowanalysis.pcm.extension.model.confidentiality.expression.LhsEnumCharacteristicReference;
-import org.palladiosimulator.pcm.seff.ExternalCallAction;
-import org.palladiosimulator.pcm.seff.SetVariableAction;
-
 /**
- * Converts Palladio models to the data flow diagram and dictionary
- * representation. Inherits from {@link Converter} to utilize shared conversion
- * logic while providing specific functionality for handling Palladio models.
+ * Converts Palladio models to the data flow diagram and dictionary representation. Inherits from {@link Converter} to
+ * utilize shared conversion logic while providing specific functionality for handling Palladio models.
  */
 public class PCMConverter extends Converter {
 
-	private final Map<AbstractPCMVertex<?>, Node> dfdNodeMap = new HashMap<>();
-	private final Map<AbstractPCMVertex<?>, AbstractTransposeFlowGraph> pcmFlowMap = new HashMap<>();
-	private DataDictionary dataDictionary;
-	private DataFlowDiagram dataFlowDiagram;
-	private Set<String> takenIds = new HashSet<>();
-
-	/**
-	 * Converts a PCM model into a DataFlowDiagramAndDictionary object.
-	 * 
-	 * @param modelLocation  Location of the model folder.
-	 * @param usageModelPath Location of the usage model.
-	 * @param allocationPath Location of the allocation.
-	 * @param nodeCharPath   Location of the node characteristics.
-	 * @param activator      Activator class of the plugin where the model resides.
-	 * @return DataFlowDiagramAndDictionary object representing the converted
-	 *         Palladio model.
-	 */
-	public DataFlowDiagramAndDictionary pcmToDFD(String modelLocation, String usageModelPath, String allocationPath,
-			String nodeCharPath, Class<? extends Plugin> activator) {
-		this.logger.setLevel(Level.TRACE);
-		DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
-				.modelProjectName(modelLocation).usePluginActivator(activator).useUsageModel(usageModelPath)
-				.useAllocationModel(allocationPath).useNodeCharacteristicsModel(nodeCharPath).build();
-
-		analysis.setLoggerLevel(Level.TRACE);
-		analysis.initializeAnalysis();
-		var flowGraph = analysis.findFlowGraphs();
-		flowGraph.evaluate();
-
-		return processPalladio(flowGraph);
-	}
-
-	/**
-	 * Converts a PCM model into a DataFlowDiagramAndDictionary object.
-	 * 
-	 * @param modelLocation  Location of the model folder.
-	 * @param usageModelPath Location of the usage model.
-	 * @param allocationPath Location of the allocation.
-	 * @param nodeCharPath   Location of the node characteristics.
-	 * @return DataFlowDiagramAndDictionary object representing the converted
-	 *         Palladio model.
-	 */
-	public DataFlowDiagramAndDictionary pcmToDFD(String modelLocation, String usageModelPath, String allocationPath,
-			String nodeCharPath) {
-		this.logger.setLevel(Level.TRACE);
-		DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
-				.modelProjectName(modelLocation).useUsageModel(usageModelPath).useAllocationModel(allocationPath)
-				.useNodeCharacteristicsModel(nodeCharPath).build();
-
-		analysis.setLoggerLevel(Level.TRACE);
-		analysis.initializeAnalysis();
-		var flowGraph = analysis.findFlowGraphs();
-		flowGraph.evaluate();
-
-		return processPalladio(flowGraph);
-	}
-
-	public DataFlowDiagramAndDictionary pcmToDFD(FlowGraphCollection flowGraph) {
-		return processPalladio(flowGraph);
-	}
-
-	/**
-	 * This method compute the complete name of a PCM vertex depending on its type
-	 * 
-	 * @param vertex
-	 * @return String containing the complete name
-	 */
-	public static String computeCompleteName(AbstractPCMVertex<?> vertex) {
-		if (vertex instanceof CallingSEFFPCMVertex cast) {
-			if (cast.isCalling()) {
-				return "Calling " + cast.getReferencedElement().getEntityName();
-			} else {
-				return "Returning " + cast.getReferencedElement().getEntityName();
-			}
-		}
-		if (vertex instanceof CallingUserPCMVertex cast) {
-			if (cast.isCalling()) {
-				return "Calling " + cast.getReferencedElement().getEntityName();
-			} else {
-				return "Returning " + cast.getReferencedElement().getEntityName();
-			}
-		}
-		if (vertex instanceof SEFFPCMVertex<?> cast) {
-			String elementName = cast.getReferencedElement().getEntityName();
-			if (cast.getReferencedElement() instanceof StartAction) {
-				Optional<ResourceDemandingSEFF> seff = PCMQueryUtils.findParentOfType(cast.getReferencedElement(),
-						ResourceDemandingSEFF.class, false);
-				if (seff.isPresent()) {
-					elementName = "Beginning " + seff.get().getDescribedService__SEFF().getEntityName();
-				}
-				if (cast.isBranching() && seff.isPresent()) {
-					BranchAction branchAction = PCMQueryUtils
-							.findParentOfType(cast.getReferencedElement(), BranchAction.class, false)
-							.orElseThrow(() -> new IllegalStateException("Cannot find branch action"));
-					AbstractBranchTransition branchTransition = PCMQueryUtils
-							.findParentOfType(cast.getReferencedElement(), AbstractBranchTransition.class, false)
-							.orElseThrow(() -> new IllegalStateException("Cannot find branch transition"));
-					elementName = "Branching " + seff.get().getDescribedService__SEFF().getEntityName() + "."
-							+ branchAction.getEntityName() + "." + branchTransition.getEntityName();
-				}
-			}
-			if (cast.getReferencedElement() instanceof StopAction) {
-				Optional<ResourceDemandingSEFF> seff = PCMQueryUtils.findParentOfType(cast.getReferencedElement(),
-						ResourceDemandingSEFF.class, false);
-				if (seff.isPresent()) {
-					elementName = "Ending " + seff.get().getDescribedService__SEFF().getEntityName();
-				}
-			}
-			return elementName;
-		}
-		if (vertex instanceof UserPCMVertex<?> cast) {
-			if (cast.getReferencedElement() instanceof Start || cast.getReferencedElement() instanceof Stop) {
-				return cast.getEntityNameOfScenarioBehaviour();
-			}
-			return cast.getReferencedElement().getEntityName();
-		}
-		return vertex.getReferencedElement().getEntityName();
-	}
-
-	private DataFlowDiagramAndDictionary processPalladio(FlowGraphCollection flowGraphCollection) {
-		dataDictionary = datadictionaryFactory.eINSTANCE.createDataDictionary();
-		dataFlowDiagram = dataflowdiagramFactory.eINSTANCE.createDataFlowDiagram();
-		for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
-			transposeFlowGraph.getVertices().stream().filter(it -> it instanceof AbstractPCMVertex<?>)
-					.map(it -> (AbstractPCMVertex<?>) it).forEach(it -> processVertex(it, transposeFlowGraph));
-		}
-		for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
-			transposeFlowGraph.getVertices().stream().filter(it -> it instanceof AbstractPCMVertex<?>)
-					.map(it -> (AbstractPCMVertex<?>) it).forEach(it -> createFlowsForVertex(it));
-		}
-		for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
-			transposeFlowGraph.getVertices().stream().filter(it -> it instanceof AbstractPCMVertex<?>)
-					.map(it -> (AbstractPCMVertex<?>) it).forEach(it -> createBehavior(it));
-		}
-
-		flowGraphCollection.getTransposeFlowGraphs().stream().map(it -> it.getSink()).forEach(sink -> {
-			var node = dfdNodeMap.get(sink);
-			node.getBehavior().getOutPin().clear();
-			node.getBehavior().getAssignment().clear();
-		});
-
-		return new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary);
-	}
-
-	/**
-	 * Creates DFD Node from PCM Vertex and annotates the pins according to incoming
-	 * and outgoing data characteristics
-	 * 
-	 * @param pcmVertex PCm Vertex to be converted
-	 */
-	private void processVertex(AbstractPCMVertex<? extends Entity> pcmVertex, AbstractTransposeFlowGraph transposeFlowGraph) {
-		this.pcmFlowMap.put(pcmVertex, transposeFlowGraph);
-		var node = getDFDNode(pcmVertex);
-		createPinsFromVertex(node, pcmVertex);
-	}
-
-	/**
-	 * Creates the flows to each DFD Node according to previous elements
-	 * 
-	 * @param pcmVertex PCMVertex whichs corresponding note is the flow target
-	 */
-	private void createFlowsForVertex(AbstractPCMVertex<? extends Entity> pcmVertex) {
-		pcmVertex.getPreviousElements().forEach(previousElement -> createFlows(previousElement, pcmVertex));
-	}
-
-	/**
-	 * Creates the behaviour for the DFD Node from its corresponding PCM logic
-	 * 
-	 * @param pcmVertex PCMVertex whichs corresponding note is to be annotated
-	 */
-	private void createBehavior(AbstractPCMVertex<? extends Entity> pcmVertex) {
-		var node = getDFDNode(pcmVertex);
-		convertBehavior(pcmVertex, node, dataDictionary);
-	}
-
-	/**
-	 * Creates and adds the pins to the node supplied according to the incoming and
-	 * outgoing data characteristics of the supplied vertex
-	 * 
-	 * @param node      to be annotated
-	 * @param pcmVertex holding the data characteristics
-	 */
-	private void createPinsFromVertex(Node node, AbstractPCMVertex<? extends Entity> pcmVertex) {
-		var behaviour = node.getBehavior();
-		pcmVertex.getAllIncomingDataCharacteristics().forEach(idc -> {
-			var pin = datadictionaryFactory.eINSTANCE.createPin();
-			pin.setEntityName(idc.getVariableName());
-			behaviour.getInPin().add(pin);
-		});
-		pcmVertex.getAllOutgoingDataCharacteristics().forEach(odc -> {
-			var pin = datadictionaryFactory.eINSTANCE.createPin();
-			pin.setEntityName(odc.getVariableName());
-			behaviour.getOutPin().add(pin);
-		});
-	}
-
-	/**
-	 * Creates flows between the nodes corresponding to the source and destination
-	 * vertex
-	 * 
-	 * @param sourceVertex
-	 * @param destinationVertex
-	 */
-	private void createFlows(AbstractPCMVertex<? extends Entity> sourceVertex,
-			AbstractPCMVertex<? extends Entity> destinationVertex) {
-		var intersectingDataCharacteristics = sourceVertex.getAllOutgoingDataCharacteristics().stream()
-				.map(odc -> odc.getVariableName()).filter(odc -> {
-					return destinationVertex.getAllIncomingDataCharacteristics().stream()
-							.map(idc -> idc.getVariableName()).toList().contains(odc);
-				}).toList();
-		if (intersectingDataCharacteristics.size() == 0) {
-			createEmptyFlowForNoDataCharacteristics(sourceVertex, destinationVertex);
-		} else {
-			createFlowForListOfCharacteristics(sourceVertex, destinationVertex, intersectingDataCharacteristics);
-		}
-	}
-
-	/**
-	 * Creates flows in case of source and destination vertex holding similar data
-	 * characteristics
-	 * 
-	 * @param sourceVertex
-	 * @param destinationVertex
-	 * @param intersectingDataCharacteristics
-	 */
-	private void createFlowForListOfCharacteristics(AbstractPCMVertex<? extends Entity> sourceVertex,
-			AbstractPCMVertex<? extends Entity> destinationVertex, List<String> intersectingDataCharacteristics) {
-		var sourceNode = dfdNodeMap.get(sourceVertex);
-		var destinationNode = dfdNodeMap.get(destinationVertex);
-		for (var dataCharacteristic : intersectingDataCharacteristics) {
-			var flow = dataflowdiagramFactory.eINSTANCE.createFlow();
-			var inPin = destinationNode.getBehavior().getInPin().stream()
-					.filter(pin -> pin.getEntityName().equals(dataCharacteristic)).toList().get(0);
-			var outPin = sourceNode.getBehavior().getOutPin().stream()
-					.filter(pin -> pin.getEntityName().equals(dataCharacteristic)).toList().get(0);
-
-			flow.setEntityName(dataCharacteristic);
-			flow.setDestinationNode(destinationNode);
-			flow.setSourceNode(sourceNode);
-			flow.setDestinationPin(inPin);
-			flow.setSourcePin(outPin);
-
-			dataFlowDiagram.getFlows().add(flow);
-		}
-	}
-
-	/**
-	 * Creates flow in case of no similar characteristics between source and
-	 * destination node
-	 * 
-	 * @param sourceVertex
-	 * @param destinationVertex
-	 */
-	private void createEmptyFlowForNoDataCharacteristics(AbstractPCMVertex<? extends Entity> sourceVertex,
-			AbstractPCMVertex<? extends Entity> destinationVertex) {
-		var sourceNode = dfdNodeMap.get(sourceVertex);
-		var destinationNode = dfdNodeMap.get(destinationVertex);
-
-		var flow = dataflowdiagramFactory.eINSTANCE.createFlow();
-		var inPin = datadictionaryFactory.eINSTANCE.createPin();
-		var outPin = datadictionaryFactory.eINSTANCE.createPin();
-
-		inPin.setEntityName("");
-		outPin.setEntityName("");
-
-		flow.setDestinationNode(destinationNode);
-		flow.setSourceNode(sourceNode);
-		flow.setDestinationPin(inPin);
-		flow.setSourcePin(outPin);
-		flow.setEntityName("");
-		dataFlowDiagram.getFlows().add(flow);
-
-		sourceNode.getBehavior().getOutPin().add(outPin);
-		destinationNode.getBehavior().getInPin().add(inPin);
-
-		var assignment = datadictionaryFactory.eINSTANCE.createAssignment();
-		assignment.setTerm(datadictionaryFactory.eINSTANCE.createTRUE());
-
-		assignment.setOutputPin(outPin);
-	}
-
-	/**
-	 * Returns the corresponding DFD node or creates and annotates it with
-	 * properties
-	 * 
-	 * @param pcmVertex to be converted
-	 * @return The corresponding or created DFD Node
-	 */
-	private Node getDFDNode(AbstractPCMVertex<? extends Entity> pcmVertex) {
-		Node dfdNode = dfdNodeMap.get(pcmVertex);
-
-		if (dfdNode == null) {
-			dfdNode = createCorrespondingDFDNode(pcmVertex);
-			addNodeCharacteristicsToNode(dfdNode, pcmVertex.getAllVertexCharacteristics());
-			dfdNodeMap.put(pcmVertex, dfdNode);
-		}
-
-		return dfdNode;
-	}
-
-	/**
-	 * Creates DFD Node from corresponding PCM Vertex
-	 * 
-	 * @param pcmVertex to be converted
-	 * @return new DFD Node
-	 */
-	private Node createCorrespondingDFDNode(AbstractPCMVertex<? extends Entity> pcmVertex) {
-		Node node;
-
-		if (pcmVertex instanceof UserPCMVertex<?>) {
-			node = dataflowdiagramFactory.eINSTANCE.createExternal();
-		} else if (pcmVertex instanceof SEFFPCMVertex<?>) {
-			node = dataflowdiagramFactory.eINSTANCE.createProcess();
-		} else {
-			logger.error("Unregcognized palladio element");
-			return null;
-		}
-
-		Behavior behaviour = datadictionaryFactory.eINSTANCE.createBehavior();
-
-		node.setEntityName(computeCompleteName(pcmVertex));
-
-		var id = pcmVertex.getReferencedElement().getId();
-		int occurrences = 1;
-		while (takenIds.contains(id)) {
-			id = pcmVertex.getReferencedElement().getId() + "_" + occurrences;
-			occurrences++;
-		}
-
-		node.setId(id);
-		takenIds.add(id);
-		node.setBehavior(behaviour);
-		dataDictionary.getBehavior().add(behaviour);
-		dataFlowDiagram.getNodes().add(node);
-		return node;
-	}
-
-	/**
-	 * Converts the CharacteristicsValues supplied into labels and adds them as DFD
-	 * Node properties
-	 * 
-	 * @param node       the node to add characteristics to
-	 * @param charValues the list of characteristic values
-	 */
-	private void addNodeCharacteristicsToNode(Node node, List<CharacteristicValue> charValues) {
-		for (CharacteristicValue charValue : charValues) {
-			LabelType type = this.getOrCreateLabelType(charValue.getTypeName());
-			Label label = this.getOrCreateDFDLabel(charValue.getValueName(), type);
-			if (!node.getProperties().contains(label)) {
-				node.getProperties().add(label);
-			}
-		}
-	}
-
-	/**
-	 * Get or create a LabelType with the supplied String name
-	 * 
-	 * @param name the name of the LabelType
-	 * @return the LabelType
-	 */
-	private LabelType getOrCreateLabelType(String name) {
-		LabelType type = dataDictionary.getLabelTypes().stream().filter(f -> f.getEntityName().equals(name)).findFirst()
-				.orElseGet(() -> createLabelType(name));
-
-		return type;
-	}
-
-	/**
-	 * Get or create a Label with the supplied String name and LabelType
-	 * 
-	 * @param labelName the name of the Label
-	 * @param type      the LabelType
-	 * @return the Label
-	 */
-	private Label getOrCreateDFDLabel(String labelName, LabelType type) {
-		Label label = type.getLabel().stream().filter(f -> f.getEntityName().equals(labelName)).findFirst()
-				.orElseGet(() -> createLabel(labelName, type));
-
-		return label;
-	}
-
-	/**
-	 * Creates a Label with the supplied name and adds it to the LabelType
-	 * 
-	 * @param name the name of the Label
-	 * @param type the LabelType
-	 * @return the created Label
-	 */
-	private Label createLabel(String name, LabelType type) {
-		Label label = datadictionaryFactory.eINSTANCE.createLabel();
-		label.setEntityName(name);
-		type.getLabel().add(label);
-		return label;
-	}
-
-	/**
-	 * Creates a LabelType with the supplied name
-	 * 
-	 * @param name the name of the LabelType
-	 * @return the created LabelType
-	 */
-	private LabelType createLabelType(String name) {
-		LabelType type = datadictionaryFactory.eINSTANCE.createLabelType();
-		type.setEntityName(name);
-		this.dataDictionary.getLabelTypes().add(type);
-		return type;
-	}
-
-	/**
-	 * Determines the variable characterizations for a given PCM vertex
-	 * 
-	 * @param vertex Given PCM vertex of which the variable characterizations should
-	 *               be found
-	 * @return Returns a list of variable characterizations of the given vertex
-	 */
-	private List<ConfidentialityVariableCharacterisation> getVariableCharacterizations(AbstractPCMVertex<?> vertex) {
-		if (vertex.getReferencedElement() instanceof SetVariableAction setVariableAction) {
-			return setVariableAction.getLocalVariableUsages_SetVariableAction().stream()
-					.map(VariableUsage::getVariableCharacterisation_VariableUsage).flatMap(List::stream)
-					.filter(ConfidentialityVariableCharacterisation.class::isInstance)
-					.map(ConfidentialityVariableCharacterisation.class::cast).toList();
-		} else if (vertex.getReferencedElement() instanceof ExternalCallAction externalCallAction
-				&& vertex instanceof CallingSEFFPCMVertex callingSEFFPCMVertex && callingSEFFPCMVertex.isCalling()) {
-			return externalCallAction.getInputVariableUsages__CallAction().stream()
-					.map(VariableUsage::getVariableCharacterisation_VariableUsage).flatMap(List::stream)
-					.filter(ConfidentialityVariableCharacterisation.class::isInstance)
-					.map(ConfidentialityVariableCharacterisation.class::cast).toList();
-		} else if (vertex.getReferencedElement() instanceof ExternalCallAction externalCallAction
-				&& vertex instanceof CallingSEFFPCMVertex callingSEFFPCMVertex && callingSEFFPCMVertex.isReturning()) {
-			return externalCallAction.getReturnVariableUsage__CallReturnAction().stream()
-					.map(VariableUsage::getVariableCharacterisation_VariableUsage).flatMap(List::stream)
-					.filter(ConfidentialityVariableCharacterisation.class::isInstance)
-					.map(ConfidentialityVariableCharacterisation.class::cast).toList();
-		} else if (vertex.getReferencedElement() instanceof EntryLevelSystemCall entryLevelSystemCall
-				&& vertex instanceof CallingUserPCMVertex callingUserPCMVertex && callingUserPCMVertex.isCalling()) {
-			return entryLevelSystemCall.getInputParameterUsages_EntryLevelSystemCall().stream()
-					.map(VariableUsage::getVariableCharacterisation_VariableUsage).flatMap(List::stream)
-					.filter(ConfidentialityVariableCharacterisation.class::isInstance)
-					.map(ConfidentialityVariableCharacterisation.class::cast).toList();
-		} else if (vertex.getReferencedElement() instanceof EntryLevelSystemCall entryLevelSystemCall
-				&& vertex instanceof CallingUserPCMVertex callingUserPCMVertex && callingUserPCMVertex.isReturning()) {
-			return entryLevelSystemCall.getOutputParameterUsages_EntryLevelSystemCall().stream()
-					.map(VariableUsage::getVariableCharacterisation_VariableUsage).flatMap(List::stream)
-					.filter(ConfidentialityVariableCharacterisation.class::isInstance)
-					.map(ConfidentialityVariableCharacterisation.class::cast).toList();
-		} else {
-			return List.of();
-		}
-	}
-
-	/**
-	 * Determines the assignments for the DFD nodes that can be inferred by the
-	 * characteristics of the PCM vertex
-	 * 
-	 * @param vertex PCM vertex of which the characteristics are read from
-	 * @param node   DFD node to which the assignments should be added
-	 * @return Returns a list of assignments that should be added to the DFD node
-	 */
-	private List<AbstractAssignment> getAssignments(AbstractPCMVertex<?> vertex, Node node) {
-		if (vertex instanceof UserPCMVertex<?> && vertex.getReferencedElement() instanceof Start) {
-			return List.of();
-		}
-		List<AbstractAssignment> assignments = new ArrayList<>();
-
-		if (vertex.getAllIncomingDataCharacteristics().isEmpty()) {
-			vertex.getAllOutgoingDataCharacteristics().forEach(it -> {
-				Pin outPin = node.getBehavior().getOutPin().stream()
-						.filter(pin -> pin.getEntityName().equals(it.getVariableName())).findAny().orElseThrow();
-				Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
-				assignment.setTerm(datadictionaryFactory.eINSTANCE.createTRUE());
-				assignment.setOutputPin(outPin);
-				assignment.getOutputLabels().addAll(it.getAllCharacteristics().stream().map(characteristicValue -> {
-					LabelType type = this.getOrCreateLabelType(characteristicValue.getTypeName());
-					return this.getOrCreateDFDLabel(characteristicValue.getValueName(), type);
-				}).toList());
-				assignments.add(assignment);
-			});
-		}
-
-		List<DataCharacteristic> dataCharacteristicsForwarded = vertex.getAllIncomingDataCharacteristics().stream()
-				.filter(it -> vertex.getAllOutgoingDataCharacteristics().stream()
-						.anyMatch(ot -> it.getVariableName().equals(ot.getVariableName())))
-				.toList();
-		for (DataCharacteristic dataCharacteristic : dataCharacteristicsForwarded) {
-			assignments.add(this.forwardCharacteristic(node, vertex, dataCharacteristic));
-		}
-		if (dataCharacteristicsForwarded.isEmpty() && vertex.getAllIncomingDataCharacteristics().isEmpty()
-				&& vertex.getAllOutgoingDataCharacteristics().isEmpty()
-				&& !(vertex instanceof UserPCMVertex<?> && ((AbstractUserAction) vertex.getReferencedElement())
-						.getScenarioBehaviour_AbstractUserAction().getUsageScenario_SenarioBehaviour() != null)) {
-			assignments.add(this.preserveControlFlow(node, vertex));
-		}
-		return assignments;
-	}
-
-	/**
-	 * Creates an assignment that forwards the given data characteristics of the PCM
-	 * vertex in the given DFD node
-	 * 
-	 * @param node               DFD node that should receive the created assignment
-	 * @param vertex             PCM vertex that determines the assignment behavior
-	 * @param dataCharacteristic Data characteristic that is forwarded
-	 * @return Returns an assignment that forwards the given data characteristic
-	 */
-	private AbstractAssignment forwardCharacteristic(Node node, AbstractPCMVertex<?> vertex,
-			DataCharacteristic dataCharacteristic) {
-		ForwardingAssignment assignment = datadictionaryFactory.eINSTANCE.createForwardingAssignment();
-		Pin inPin = node.getBehavior().getInPin().stream()
-				.filter(it -> it.getEntityName().equals(dataCharacteristic.getVariableName())).findAny()
-				.orElseThrow(() -> {
-					logger.error("Cannot find required in-pin " + dataCharacteristic.getVariableName()
-							+ " at vertex with name " + vertex);
-					return new NoSuchElementException();
-				});
-		Pin outPin = node.getBehavior().getOutPin().stream()
-				.filter(it -> it.getEntityName().equals(dataCharacteristic.getVariableName())).findAny()
-				.orElseThrow(() -> {
-					logger.error("Cannot find required out-pin " + dataCharacteristic.getVariableName()
-							+ " at vertex with name " + vertex);
-					return new NoSuchElementException();
-				});
-		assignment.getInputPins().add(inPin);
-		assignment.setOutputPin(outPin);
-		return assignment;
-	}
-
-	/**
-	 * Preserves the control flow between converted vertices, by forwarding an empty
-	 * value
-	 * 
-	 * @param node   DFD node that should reflect the control flow of the given PCM
-	 *               vertex
-	 * @param vertex PCM vertex that dictates the control flow
-	 * @return Returns an assignment that preserves the control flow between the
-	 *         elements in the conversion
-	 */
-	private AbstractAssignment preserveControlFlow(Node node, AbstractPCMVertex<?> vertex) {
-		ForwardingAssignment assignment = datadictionaryFactory.eINSTANCE.createForwardingAssignment();
-		Pin inPin = node.getBehavior().getInPin().stream().filter(it -> it.getEntityName().equals("")).findAny()
-				.orElseThrow(() -> {
-					logger.error("Cannot find required in-pin with empty name at vertex with name " + vertex);
-					return new NoSuchElementException();
-				});
-		Pin outPin = node.getBehavior().getOutPin().stream().filter(it -> it.getEntityName().equals("")).findAny()
-				.orElseThrow(() -> {
-					logger.error("Cannot find required out-pin with empty name at vertex with name " + vertex);
-					return new NoSuchElementException();
-				});
-		assignment.getInputPins().add(inPin);
-		assignment.setOutputPin(outPin);
-		return assignment;
-	}
-
-	/**
-	 * Processes the given variable characterization with the given converted DFD
-	 * behavior and node with a given PCM vertex
-	 * 
-	 * @param variableCharacterisation Variable characterization of the PCM vertex
-	 * @param behaviour                Resulting behavior of the DFD node
-	 * @param node                     DFD node that is converted to
-	 * @param vertex                   PCM vertex that is converted from
-	 * @return Returns a list of all assignments that must be added to the DFD
-	 *         behavior to reflect the PCM variable characterization
-	 */
-	private List<AbstractAssignment> processCharacterization(
-			ConfidentialityVariableCharacterisation variableCharacterisation, Behavior behaviour, Node node,
-			AbstractPCMVertex<?> vertex) {
-		var leftHandSide = (LhsEnumCharacteristicReference) variableCharacterisation.getLhs();
-
-		EnumCharacteristicType characteristicType = (EnumCharacteristicType) leftHandSide.getCharacteristicType();
-		Literal characteristicValue = leftHandSide.getLiteral();
-		AbstractNamedReference reference = variableCharacterisation.getVariableUsage_VariableCharacterisation()
-				.getNamedReference__VariableUsage();
-
-		Term rightHandSide = variableCharacterisation.getRhs();
-
-		if (characteristicType == null && characteristicValue == null) {
-			return List.of(this.processFullForwardingAssignment(node, rightHandSide, reference));
-		} else if (characteristicValue == null) {
-			return this.processHalfForwardingAssignment(node, rightHandSide, reference, vertex, behaviour,
-					characteristicType);
-		} else {
-			return List.of(this.processAssignment(node, rightHandSide, behaviour, reference, characteristicType,
-					characteristicValue));
-		}
-	}
-
-	/**
-	 * Processes a full forwarding assignment on a PCM vertex, resulting in a single
-	 * DFD forwarding assignment
-	 * 
-	 * @param node          DFD node that is converted to
-	 * @param rightHandSide Term that determines the origin of the forwarded
-	 *                      variable
-	 * @param reference     Reference that determines the destination of the
-	 *                      forwarded variable
-	 * @return Returns an DFD assignment that reflects the PCM full forwarding
-	 *         assignment
-	 */
-	private AbstractAssignment processFullForwardingAssignment(Node node, Term rightHandSide,
-			AbstractNamedReference reference) {
-		if (!(rightHandSide instanceof NamedEnumCharacteristicReference namedEnumCharacteristicReference)) {
-			return datadictionaryFactory.eINSTANCE.createForwardingAssignment();
-		}
-		ForwardingAssignment assignment = datadictionaryFactory.eINSTANCE.createForwardingAssignment();
-		Pin outPin = node.getBehavior().getOutPin().stream()
-				.filter(it -> it.getEntityName().equals(reference.getReferenceName())).findAny().orElseThrow();
-		assignment.setOutputPin(outPin);
-		Optional<Pin> inPin = node.getBehavior().getInPin().stream().filter(
-				it -> it.getEntityName().equals(namedEnumCharacteristicReference.getNamedReference().getReferenceName())
-						|| it.getEntityName().equals(""))
-				.findAny();
-		if (inPin.isPresent()) {
-			assignment.getInputPins().add(inPin.get());
-		} else {
-			logger.warn("One StoEx references incoming data that is not incoming!");
-		}
-		return assignment;
-	}
-
-	/**
-	 * Process a half forwarding assignment on a PCM vertex, resulting in multiple
-	 * DFD assignments that model the assignment
-	 * 
-	 * @param node               DFD node that is converted to
-	 * @param rightHandSide      Term that determines the data characteristic origin
-	 * @param reference          Reference that determines the data characteristic
-	 *                           destination
-	 * @param vertex             PCM vertex that has the given assignment
-	 * @param behaviour          DFD behavior that is converted to
-	 * @param characteristicType PCM characteristic type that is forwarded
-	 * @return Returns a list of abstract assignments that reflects the forwarding
-	 *         of all characteristic values of a given type
-	 */
-	private List<AbstractAssignment> processHalfForwardingAssignment(Node node, Term rightHandSide,
-			AbstractNamedReference reference, AbstractPCMVertex<?> vertex, Behavior behaviour,
-			EnumCharacteristicType characteristicType) {
-		List<AbstractAssignment> assignments = new ArrayList<>();
-		List<Literal> forwardedValues = characteristicType.getType().getLiterals();
-		for (Literal value : forwardedValues) {
-			Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
-			LabelType labelType = this.getOrCreateLabelType(characteristicType.getName());
-			Label label = this.getOrCreateDFDLabel(value.getName(), labelType);
-			assignment.getOutputLabels().add(label);
-
-			Pin outPin = node.getBehavior().getOutPin().stream()
-					.filter(it -> it.getEntityName().equals(reference.getReferenceName())).findAny().orElseThrow();
-			assignment.setOutputPin(outPin);
-			org.dataflowanalysis.dfd.datadictionary.Term term = parseTerm(rightHandSide, dataDictionary, label);
-			
-			assignment.setTerm(term);
-			if (rightHandSide instanceof NamedEnumCharacteristicReference namedEnumCharacteristicReference) {
-				Pin inPin = node.getBehavior().getInPin().stream()
-						.filter(it -> it.getEntityName()
-								.equals(namedEnumCharacteristicReference.getNamedReference().getReferenceName()))
-						.findAny().orElseThrow();
-				assignment.getInputPins().add(inPin);
-			} else {
-				assignment.getInputPins().addAll(behaviour.getInPin());
-			}
-			assignments.add(assignment);
-		}
-		return assignments;
-	}
-
-	/**
-	 * Process an assignment on the given node with the given characteristic type
-	 * and value as well as the pin
-	 * 
-	 * @param node                DFD node that is converted to
-	 * @param rightHandSide       Condition that reflects the value of the targeted
-	 *                            data characteristic
-	 * @param behaviour           DFD behavior that is converted to
-	 * @param reference           Reference that determines the destination of the
-	 *                            assignment
-	 * @param characteristicType  Characteristic type that is assigned to
-	 * @param characteristicValue Characteristic value that is assigned to
-	 * @return Returns an assignment that models the PCM behavior at the given
-	 *         vertex
-	 */
-	private AbstractAssignment processAssignment(Node node, Term rightHandSide, Behavior behaviour,
-			AbstractNamedReference reference, EnumCharacteristicType characteristicType, Literal characteristicValue) {
-		Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
-		LabelType labelType = getOrCreateLabelType(characteristicType.getName());
-
-		Label label = getOrCreateDFDLabel(characteristicValue.getName(), labelType);
-		assignment.getOutputLabels().add(label);
-
-		Pin outPin = node.getBehavior().getOutPin().stream()
-				.filter(it -> it.getEntityName().equals(reference.getReferenceName())).findAny().orElseThrow();
-		assignment.setOutputPin(outPin);
-		org.dataflowanalysis.dfd.datadictionary.Term term = parseTerm(rightHandSide, dataDictionary);
-		assignment.setTerm(term);
-		if (rightHandSide instanceof NamedEnumCharacteristicReference namedEnumCharacteristicReference) {
-			Pin inPin = node.getBehavior().getInPin().stream()
-					.filter(it -> it.getEntityName()
-							.equals(namedEnumCharacteristicReference.getNamedReference().getReferenceName()))
-					.findAny().orElseThrow();
-			assignment.getInputPins().add(inPin);
-		} else {
-			assignment.getInputPins().addAll(behaviour.getInPin());
-		}
-		return assignment;
-	}
-
-	/**
-	 * Converts behavior from PCM Vertex to Node and adds it to the Data Dictionary
-	 * 
-	 * @param pcmVertex      the PCM Vertex
-	 * @param node           the DFD Node
-	 * @param dataDictionary the Data Dictionary
-	 */
-	public void convertBehavior(AbstractPCMVertex<?> pcmVertex, Node node, DataDictionary dataDictionary) {
-		List<ConfidentialityVariableCharacterisation> variableCharacterisations = this
-				.getVariableCharacterizations(pcmVertex);
-
-		Behavior behaviour = node.getBehavior();
-		List<AbstractAssignment> assignments = this.getAssignments(pcmVertex, node);
-		for (ConfidentialityVariableCharacterisation variableCharacterization : variableCharacterisations) {
-			assignments.addAll(this.processCharacterization(variableCharacterization, behaviour, node, pcmVertex));
-		}
-		behaviour.getAssignment().clear();
-		behaviour.getAssignment().addAll(assignments);
-
-		behaviour.getOutPin().stream().forEach(pin -> {
-			Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
-			assignment.setEntityName("Dummy Assignment");
-			assignment.getInputPins().addAll(behaviour.getInPin());
-			assignment.setOutputPin(pin);
-			assignment.setTerm(datadictionaryFactory.eINSTANCE.createTRUE());
-			behaviour.getAssignment().add(assignment);
-		});
-	}
-	
-	/**
-	 * Parses a Term object into a corresponding Data Dictionary Term
-	 * 
-	 * @param rightHandSide  the Term object to parse
-	 * @param dataDictionary the Data Dictionary
-	 * @return the parsed Term
-	 */
-	public org.dataflowanalysis.dfd.datadictionary.Term parseTerm(Term rightHandSide, DataDictionary dataDictionary, Label wildcardLabel) {
-		if (rightHandSide instanceof True) {
-			return datadictionaryFactory.eINSTANCE.createTRUE();
-		} else if (rightHandSide instanceof False) {
-			NOT term = datadictionaryFactory.eINSTANCE.createNOT();
-			term.setNegatedTerm(datadictionaryFactory.eINSTANCE.createTRUE());
-			return term;
-		} else if (rightHandSide instanceof Or or) {
-			OR term = datadictionaryFactory.eINSTANCE.createOR();
-			term.getTerms().add(parseTerm(or.getLeft(), dataDictionary, wildcardLabel));
-			term.getTerms().add(parseTerm(or.getRight(), dataDictionary, wildcardLabel));
-			return term;
-		} else if (rightHandSide instanceof And and) {
-			AND term = datadictionaryFactory.eINSTANCE.createAND();
-			term.getTerms().add(parseTerm(and.getLeft(), dataDictionary, wildcardLabel));
-			term.getTerms().add(parseTerm(and.getRight(), dataDictionary, wildcardLabel));
-			return term;
-		} else if (rightHandSide instanceof NamedEnumCharacteristicReference characteristicReference) {
-			LabelReference term = datadictionaryFactory.eINSTANCE.createLabelReference();
-			LabelType labelType = this.getOrCreateLabelType(characteristicReference.getCharacteristicType().getName());
-			if (characteristicReference.getLiteral() != null) {
-				Label label = this.getOrCreateDFDLabel(characteristicReference.getLiteral().getName(), labelType);
-				term.setLabel(label);
-			} else {
-				term.setLabel(wildcardLabel);
-			}
-			return term;
-		}
-		throw new IllegalStateException();
-	}
-
-	/**
-	 * Parses a Term object into a corresponding Data Dictionary Term
-	 * 
-	 * @param rightHandSide  the Term object to parse
-	 * @param dataDictionary the Data Dictionary
-	 * @return the parsed Term
-	 */
-	public org.dataflowanalysis.dfd.datadictionary.Term parseTerm(Term rightHandSide, DataDictionary dataDictionary) {
-		return this.parseTerm(rightHandSide, dataDictionary, null);
-	}
-
-	public Map<AbstractPCMVertex<?>, Node> getDfdNodeMap() {
-		return dfdNodeMap;
-	}
-
-	public Map<AbstractPCMVertex<?>, AbstractTransposeFlowGraph> getPcmFlowMap() {
-		return pcmFlowMap;
-	}
+    private final Map<AbstractPCMVertex<?>, Node> dfdNodeMap = new HashMap<>();
+    private final Map<AbstractPCMVertex<?>, AbstractTransposeFlowGraph> pcmFlowMap = new HashMap<>();
+    private DataDictionary dataDictionary;
+    private DataFlowDiagram dataFlowDiagram;
+    private Set<String> takenIds = new HashSet<>();
+
+    /**
+     * Converts a PCM model into a DataFlowDiagramAndDictionary object.
+     * @param modelLocation Location of the model folder.
+     * @param usageModelPath Location of the usage model.
+     * @param allocationPath Location of the allocation.
+     * @param nodeCharPath Location of the node characteristics.
+     * @param activator Activator class of the plugin where the model resides.
+     * @return DataFlowDiagramAndDictionary object representing the converted Palladio model.
+     */
+    public DataFlowDiagramAndDictionary pcmToDFD(String modelLocation, String usageModelPath, String allocationPath, String nodeCharPath,
+            Class<? extends Plugin> activator) {
+        this.logger.setLevel(Level.TRACE);
+        DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
+                .modelProjectName(modelLocation)
+                .usePluginActivator(activator)
+                .useUsageModel(usageModelPath)
+                .useAllocationModel(allocationPath)
+                .useNodeCharacteristicsModel(nodeCharPath)
+                .build();
+
+        analysis.setLoggerLevel(Level.TRACE);
+        analysis.initializeAnalysis();
+        var flowGraph = analysis.findFlowGraphs();
+        flowGraph.evaluate();
+
+        return processPalladio(flowGraph);
+    }
+
+    /**
+     * Converts a PCM model into a DataFlowDiagramAndDictionary object.
+     * @param modelLocation Location of the model folder.
+     * @param usageModelPath Location of the usage model.
+     * @param allocationPath Location of the allocation.
+     * @param nodeCharPath Location of the node characteristics.
+     * @return DataFlowDiagramAndDictionary object representing the converted Palladio model.
+     */
+    public DataFlowDiagramAndDictionary pcmToDFD(String modelLocation, String usageModelPath, String allocationPath, String nodeCharPath) {
+        this.logger.setLevel(Level.TRACE);
+        DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
+                .modelProjectName(modelLocation)
+                .useUsageModel(usageModelPath)
+                .useAllocationModel(allocationPath)
+                .useNodeCharacteristicsModel(nodeCharPath)
+                .build();
+
+        analysis.setLoggerLevel(Level.TRACE);
+        analysis.initializeAnalysis();
+        var flowGraph = analysis.findFlowGraphs();
+        flowGraph.evaluate();
+
+        return processPalladio(flowGraph);
+    }
+
+    public DataFlowDiagramAndDictionary pcmToDFD(FlowGraphCollection flowGraph) {
+        return processPalladio(flowGraph);
+    }
+
+    /**
+     * This method compute the complete name of a PCM vertex depending on its type
+     * @param vertex
+     * @return String containing the complete name
+     */
+    public static String computeCompleteName(AbstractPCMVertex<?> vertex) {
+        if (vertex instanceof CallingSEFFPCMVertex cast) {
+            if (cast.isCalling()) {
+                return "Calling " + cast.getReferencedElement()
+                        .getEntityName();
+            } else {
+                return "Returning " + cast.getReferencedElement()
+                        .getEntityName();
+            }
+        }
+        if (vertex instanceof CallingUserPCMVertex cast) {
+            if (cast.isCalling()) {
+                return "Calling " + cast.getReferencedElement()
+                        .getEntityName();
+            } else {
+                return "Returning " + cast.getReferencedElement()
+                        .getEntityName();
+            }
+        }
+        if (vertex instanceof SEFFPCMVertex<?> cast) {
+            String elementName = cast.getReferencedElement()
+                    .getEntityName();
+            if (cast.getReferencedElement() instanceof StartAction) {
+                Optional<ResourceDemandingSEFF> seff = PCMQueryUtils.findParentOfType(cast.getReferencedElement(), ResourceDemandingSEFF.class,
+                        false);
+                if (seff.isPresent()) {
+                    elementName = "Beginning " + seff.get()
+                            .getDescribedService__SEFF()
+                            .getEntityName();
+                }
+                if (cast.isBranching() && seff.isPresent()) {
+                    BranchAction branchAction = PCMQueryUtils.findParentOfType(cast.getReferencedElement(), BranchAction.class, false)
+                            .orElseThrow(() -> new IllegalStateException("Cannot find branch action"));
+                    AbstractBranchTransition branchTransition = PCMQueryUtils
+                            .findParentOfType(cast.getReferencedElement(), AbstractBranchTransition.class, false)
+                            .orElseThrow(() -> new IllegalStateException("Cannot find branch transition"));
+                    elementName = "Branching " + seff.get()
+                            .getDescribedService__SEFF()
+                            .getEntityName() + "." + branchAction.getEntityName() + "." + branchTransition.getEntityName();
+                }
+            }
+            if (cast.getReferencedElement() instanceof StopAction) {
+                Optional<ResourceDemandingSEFF> seff = PCMQueryUtils.findParentOfType(cast.getReferencedElement(), ResourceDemandingSEFF.class,
+                        false);
+                if (seff.isPresent()) {
+                    elementName = "Ending " + seff.get()
+                            .getDescribedService__SEFF()
+                            .getEntityName();
+                }
+            }
+            return elementName;
+        }
+        if (vertex instanceof UserPCMVertex<?> cast) {
+            if (cast.getReferencedElement() instanceof Start || cast.getReferencedElement() instanceof Stop) {
+                return cast.getEntityNameOfScenarioBehaviour();
+            }
+            return cast.getReferencedElement()
+                    .getEntityName();
+        }
+        return vertex.getReferencedElement()
+                .getEntityName();
+    }
+
+    private DataFlowDiagramAndDictionary processPalladio(FlowGraphCollection flowGraphCollection) {
+        dataDictionary = datadictionaryFactory.eINSTANCE.createDataDictionary();
+        dataFlowDiagram = dataflowdiagramFactory.eINSTANCE.createDataFlowDiagram();
+        for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
+            transposeFlowGraph.getVertices()
+                    .stream()
+                    .filter(it -> it instanceof AbstractPCMVertex<?>)
+                    .map(it -> (AbstractPCMVertex<?>) it)
+                    .forEach(it -> processVertex(it, transposeFlowGraph));
+        }
+        for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
+            transposeFlowGraph.getVertices()
+                    .stream()
+                    .filter(it -> it instanceof AbstractPCMVertex<?>)
+                    .map(it -> (AbstractPCMVertex<?>) it)
+                    .forEach(it -> createFlowsForVertex(it));
+        }
+        for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraphCollection.getTransposeFlowGraphs()) {
+            transposeFlowGraph.getVertices()
+                    .stream()
+                    .filter(it -> it instanceof AbstractPCMVertex<?>)
+                    .map(it -> (AbstractPCMVertex<?>) it)
+                    .forEach(it -> createBehavior(it));
+        }
+
+        flowGraphCollection.getTransposeFlowGraphs()
+                .stream()
+                .map(it -> it.getSink())
+                .forEach(sink -> {
+                    var node = dfdNodeMap.get(sink);
+                    node.getBehavior()
+                            .getOutPin()
+                            .clear();
+                    node.getBehavior()
+                            .getAssignment()
+                            .clear();
+                });
+
+        return new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary);
+    }
+
+    /**
+     * Creates DFD Node from PCM Vertex and annotates the pins according to incoming and outgoing data characteristics
+     * @param pcmVertex PCm Vertex to be converted
+     */
+    private void processVertex(AbstractPCMVertex<? extends Entity> pcmVertex, AbstractTransposeFlowGraph transposeFlowGraph) {
+        this.pcmFlowMap.put(pcmVertex, transposeFlowGraph);
+        var node = getDFDNode(pcmVertex);
+        createPinsFromVertex(node, pcmVertex);
+    }
+
+    /**
+     * Creates the flows to each DFD Node according to previous elements
+     * @param pcmVertex PCMVertex whichs corresponding note is the flow target
+     */
+    private void createFlowsForVertex(AbstractPCMVertex<? extends Entity> pcmVertex) {
+        pcmVertex.getPreviousElements()
+                .forEach(previousElement -> createFlows(previousElement, pcmVertex));
+    }
+
+    /**
+     * Creates the behaviour for the DFD Node from its corresponding PCM logic
+     * @param pcmVertex PCMVertex whichs corresponding note is to be annotated
+     */
+    private void createBehavior(AbstractPCMVertex<? extends Entity> pcmVertex) {
+        var node = getDFDNode(pcmVertex);
+        convertBehavior(pcmVertex, node, dataDictionary);
+    }
+
+    /**
+     * Creates and adds the pins to the node supplied according to the incoming and outgoing data characteristics of the
+     * supplied vertex
+     * @param node to be annotated
+     * @param pcmVertex holding the data characteristics
+     */
+    private void createPinsFromVertex(Node node, AbstractPCMVertex<? extends Entity> pcmVertex) {
+        var behaviour = node.getBehavior();
+        pcmVertex.getAllIncomingDataCharacteristics()
+                .forEach(idc -> {
+                    var pin = datadictionaryFactory.eINSTANCE.createPin();
+                    pin.setEntityName(idc.getVariableName());
+                    behaviour.getInPin()
+                            .add(pin);
+                });
+        pcmVertex.getAllOutgoingDataCharacteristics()
+                .forEach(odc -> {
+                    var pin = datadictionaryFactory.eINSTANCE.createPin();
+                    pin.setEntityName(odc.getVariableName());
+                    behaviour.getOutPin()
+                            .add(pin);
+                });
+    }
+
+    /**
+     * Creates flows between the nodes corresponding to the source and destination vertex
+     * @param sourceVertex
+     * @param destinationVertex
+     */
+    private void createFlows(AbstractPCMVertex<? extends Entity> sourceVertex, AbstractPCMVertex<? extends Entity> destinationVertex) {
+        var intersectingDataCharacteristics = sourceVertex.getAllOutgoingDataCharacteristics()
+                .stream()
+                .map(odc -> odc.getVariableName())
+                .filter(odc -> {
+                    return destinationVertex.getAllIncomingDataCharacteristics()
+                            .stream()
+                            .map(idc -> idc.getVariableName())
+                            .toList()
+                            .contains(odc);
+                })
+                .toList();
+        if (intersectingDataCharacteristics.size() == 0) {
+            createEmptyFlowForNoDataCharacteristics(sourceVertex, destinationVertex);
+        } else {
+            createFlowForListOfCharacteristics(sourceVertex, destinationVertex, intersectingDataCharacteristics);
+        }
+    }
+
+    /**
+     * Creates flows in case of source and destination vertex holding similar data characteristics
+     * @param sourceVertex
+     * @param destinationVertex
+     * @param intersectingDataCharacteristics
+     */
+    private void createFlowForListOfCharacteristics(AbstractPCMVertex<? extends Entity> sourceVertex,
+            AbstractPCMVertex<? extends Entity> destinationVertex, List<String> intersectingDataCharacteristics) {
+        var sourceNode = dfdNodeMap.get(sourceVertex);
+        var destinationNode = dfdNodeMap.get(destinationVertex);
+        for (var dataCharacteristic : intersectingDataCharacteristics) {
+            var flow = dataflowdiagramFactory.eINSTANCE.createFlow();
+            var inPin = destinationNode.getBehavior()
+                    .getInPin()
+                    .stream()
+                    .filter(pin -> pin.getEntityName()
+                            .equals(dataCharacteristic))
+                    .toList()
+                    .get(0);
+            var outPin = sourceNode.getBehavior()
+                    .getOutPin()
+                    .stream()
+                    .filter(pin -> pin.getEntityName()
+                            .equals(dataCharacteristic))
+                    .toList()
+                    .get(0);
+
+            flow.setEntityName(dataCharacteristic);
+            flow.setDestinationNode(destinationNode);
+            flow.setSourceNode(sourceNode);
+            flow.setDestinationPin(inPin);
+            flow.setSourcePin(outPin);
+
+            dataFlowDiagram.getFlows()
+                    .add(flow);
+        }
+    }
+
+    /**
+     * Creates flow in case of no similar characteristics between source and destination node
+     * @param sourceVertex
+     * @param destinationVertex
+     */
+    private void createEmptyFlowForNoDataCharacteristics(AbstractPCMVertex<? extends Entity> sourceVertex,
+            AbstractPCMVertex<? extends Entity> destinationVertex) {
+        var sourceNode = dfdNodeMap.get(sourceVertex);
+        var destinationNode = dfdNodeMap.get(destinationVertex);
+
+        var flow = dataflowdiagramFactory.eINSTANCE.createFlow();
+        var inPin = datadictionaryFactory.eINSTANCE.createPin();
+        var outPin = datadictionaryFactory.eINSTANCE.createPin();
+
+        inPin.setEntityName("");
+        outPin.setEntityName("");
+
+        flow.setDestinationNode(destinationNode);
+        flow.setSourceNode(sourceNode);
+        flow.setDestinationPin(inPin);
+        flow.setSourcePin(outPin);
+        flow.setEntityName("");
+        dataFlowDiagram.getFlows()
+                .add(flow);
+
+        sourceNode.getBehavior()
+                .getOutPin()
+                .add(outPin);
+        destinationNode.getBehavior()
+                .getInPin()
+                .add(inPin);
+
+        var assignment = datadictionaryFactory.eINSTANCE.createAssignment();
+        assignment.setTerm(datadictionaryFactory.eINSTANCE.createTRUE());
+
+        assignment.setOutputPin(outPin);
+    }
+
+    /**
+     * Returns the corresponding DFD node or creates and annotates it with properties
+     * @param pcmVertex to be converted
+     * @return The corresponding or created DFD Node
+     */
+    private Node getDFDNode(AbstractPCMVertex<? extends Entity> pcmVertex) {
+        Node dfdNode = dfdNodeMap.get(pcmVertex);
+
+        if (dfdNode == null) {
+            dfdNode = createCorrespondingDFDNode(pcmVertex);
+            addNodeCharacteristicsToNode(dfdNode, pcmVertex.getAllVertexCharacteristics());
+            dfdNodeMap.put(pcmVertex, dfdNode);
+        }
+
+        return dfdNode;
+    }
+
+    /**
+     * Creates DFD Node from corresponding PCM Vertex
+     * @param pcmVertex to be converted
+     * @return new DFD Node
+     */
+    private Node createCorrespondingDFDNode(AbstractPCMVertex<? extends Entity> pcmVertex) {
+        Node node;
+
+        if (pcmVertex instanceof UserPCMVertex<?>) {
+            node = dataflowdiagramFactory.eINSTANCE.createExternal();
+        } else if (pcmVertex instanceof SEFFPCMVertex<?>) {
+            node = dataflowdiagramFactory.eINSTANCE.createProcess();
+        } else {
+            logger.error("Unregcognized palladio element");
+            return null;
+        }
+
+        Behavior behaviour = datadictionaryFactory.eINSTANCE.createBehavior();
+
+        node.setEntityName(computeCompleteName(pcmVertex));
+
+        var id = pcmVertex.getReferencedElement()
+                .getId();
+        int occurrences = 1;
+        while (takenIds.contains(id)) {
+            id = pcmVertex.getReferencedElement()
+                    .getId() + "_" + occurrences;
+            occurrences++;
+        }
+
+        node.setId(id);
+        takenIds.add(id);
+        node.setBehavior(behaviour);
+        dataDictionary.getBehavior()
+                .add(behaviour);
+        dataFlowDiagram.getNodes()
+                .add(node);
+        return node;
+    }
+
+    /**
+     * Converts the CharacteristicsValues supplied into labels and adds them as DFD Node properties
+     * @param node the node to add characteristics to
+     * @param charValues the list of characteristic values
+     */
+    private void addNodeCharacteristicsToNode(Node node, List<CharacteristicValue> charValues) {
+        for (CharacteristicValue charValue : charValues) {
+            LabelType type = this.getOrCreateLabelType(charValue.getTypeName());
+            Label label = this.getOrCreateDFDLabel(charValue.getValueName(), type);
+            if (!node.getProperties()
+                    .contains(label)) {
+                node.getProperties()
+                        .add(label);
+            }
+        }
+    }
+
+    /**
+     * Get or create a LabelType with the supplied String name
+     * @param name the name of the LabelType
+     * @return the LabelType
+     */
+    private LabelType getOrCreateLabelType(String name) {
+        LabelType type = dataDictionary.getLabelTypes()
+                .stream()
+                .filter(f -> f.getEntityName()
+                        .equals(name))
+                .findFirst()
+                .orElseGet(() -> createLabelType(name));
+
+        return type;
+    }
+
+    /**
+     * Get or create a Label with the supplied String name and LabelType
+     * @param labelName the name of the Label
+     * @param type the LabelType
+     * @return the Label
+     */
+    private Label getOrCreateDFDLabel(String labelName, LabelType type) {
+        Label label = type.getLabel()
+                .stream()
+                .filter(f -> f.getEntityName()
+                        .equals(labelName))
+                .findFirst()
+                .orElseGet(() -> createLabel(labelName, type));
+
+        return label;
+    }
+
+    /**
+     * Creates a Label with the supplied name and adds it to the LabelType
+     * @param name the name of the Label
+     * @param type the LabelType
+     * @return the created Label
+     */
+    private Label createLabel(String name, LabelType type) {
+        Label label = datadictionaryFactory.eINSTANCE.createLabel();
+        label.setEntityName(name);
+        type.getLabel()
+                .add(label);
+        return label;
+    }
+
+    /**
+     * Creates a LabelType with the supplied name
+     * @param name the name of the LabelType
+     * @return the created LabelType
+     */
+    private LabelType createLabelType(String name) {
+        LabelType type = datadictionaryFactory.eINSTANCE.createLabelType();
+        type.setEntityName(name);
+        this.dataDictionary.getLabelTypes()
+                .add(type);
+        return type;
+    }
+
+    /**
+     * Determines the variable characterizations for a given PCM vertex
+     * @param vertex Given PCM vertex of which the variable characterizations should be found
+     * @return Returns a list of variable characterizations of the given vertex
+     */
+    private List<ConfidentialityVariableCharacterisation> getVariableCharacterizations(AbstractPCMVertex<?> vertex) {
+        if (vertex.getReferencedElement() instanceof SetVariableAction setVariableAction) {
+            return setVariableAction.getLocalVariableUsages_SetVariableAction()
+                    .stream()
+                    .map(VariableUsage::getVariableCharacterisation_VariableUsage)
+                    .flatMap(List::stream)
+                    .filter(ConfidentialityVariableCharacterisation.class::isInstance)
+                    .map(ConfidentialityVariableCharacterisation.class::cast)
+                    .toList();
+        } else if (vertex.getReferencedElement() instanceof ExternalCallAction externalCallAction
+                && vertex instanceof CallingSEFFPCMVertex callingSEFFPCMVertex && callingSEFFPCMVertex.isCalling()) {
+            return externalCallAction.getInputVariableUsages__CallAction()
+                    .stream()
+                    .map(VariableUsage::getVariableCharacterisation_VariableUsage)
+                    .flatMap(List::stream)
+                    .filter(ConfidentialityVariableCharacterisation.class::isInstance)
+                    .map(ConfidentialityVariableCharacterisation.class::cast)
+                    .toList();
+        } else if (vertex.getReferencedElement() instanceof ExternalCallAction externalCallAction
+                && vertex instanceof CallingSEFFPCMVertex callingSEFFPCMVertex && callingSEFFPCMVertex.isReturning()) {
+            return externalCallAction.getReturnVariableUsage__CallReturnAction()
+                    .stream()
+                    .map(VariableUsage::getVariableCharacterisation_VariableUsage)
+                    .flatMap(List::stream)
+                    .filter(ConfidentialityVariableCharacterisation.class::isInstance)
+                    .map(ConfidentialityVariableCharacterisation.class::cast)
+                    .toList();
+        } else if (vertex.getReferencedElement() instanceof EntryLevelSystemCall entryLevelSystemCall
+                && vertex instanceof CallingUserPCMVertex callingUserPCMVertex && callingUserPCMVertex.isCalling()) {
+            return entryLevelSystemCall.getInputParameterUsages_EntryLevelSystemCall()
+                    .stream()
+                    .map(VariableUsage::getVariableCharacterisation_VariableUsage)
+                    .flatMap(List::stream)
+                    .filter(ConfidentialityVariableCharacterisation.class::isInstance)
+                    .map(ConfidentialityVariableCharacterisation.class::cast)
+                    .toList();
+        } else if (vertex.getReferencedElement() instanceof EntryLevelSystemCall entryLevelSystemCall
+                && vertex instanceof CallingUserPCMVertex callingUserPCMVertex && callingUserPCMVertex.isReturning()) {
+            return entryLevelSystemCall.getOutputParameterUsages_EntryLevelSystemCall()
+                    .stream()
+                    .map(VariableUsage::getVariableCharacterisation_VariableUsage)
+                    .flatMap(List::stream)
+                    .filter(ConfidentialityVariableCharacterisation.class::isInstance)
+                    .map(ConfidentialityVariableCharacterisation.class::cast)
+                    .toList();
+        } else {
+            return List.of();
+        }
+    }
+
+    /**
+     * Determines the assignments for the DFD nodes that can be inferred by the characteristics of the PCM vertex
+     * @param vertex PCM vertex of which the characteristics are read from
+     * @param node DFD node to which the assignments should be added
+     * @return Returns a list of assignments that should be added to the DFD node
+     */
+    private List<AbstractAssignment> getAssignments(AbstractPCMVertex<?> vertex, Node node) {
+        if (vertex instanceof UserPCMVertex<?> && vertex.getReferencedElement() instanceof Start) {
+            return List.of();
+        }
+        List<AbstractAssignment> assignments = new ArrayList<>();
+
+        if (vertex.getAllIncomingDataCharacteristics()
+                .isEmpty()) {
+            vertex.getAllOutgoingDataCharacteristics()
+                    .forEach(it -> {
+                        Pin outPin = node.getBehavior()
+                                .getOutPin()
+                                .stream()
+                                .filter(pin -> pin.getEntityName()
+                                        .equals(it.getVariableName()))
+                                .findAny()
+                                .orElseThrow();
+                        Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
+                        assignment.setTerm(datadictionaryFactory.eINSTANCE.createTRUE());
+                        assignment.setOutputPin(outPin);
+                        assignment.getOutputLabels()
+                                .addAll(it.getAllCharacteristics()
+                                        .stream()
+                                        .map(characteristicValue -> {
+                                            LabelType type = this.getOrCreateLabelType(characteristicValue.getTypeName());
+                                            return this.getOrCreateDFDLabel(characteristicValue.getValueName(), type);
+                                        })
+                                        .toList());
+                        assignments.add(assignment);
+                    });
+        }
+
+        List<DataCharacteristic> dataCharacteristicsForwarded = vertex.getAllIncomingDataCharacteristics()
+                .stream()
+                .filter(it -> vertex.getAllOutgoingDataCharacteristics()
+                        .stream()
+                        .anyMatch(ot -> it.getVariableName()
+                                .equals(ot.getVariableName())))
+                .toList();
+        for (DataCharacteristic dataCharacteristic : dataCharacteristicsForwarded) {
+            assignments.add(this.forwardCharacteristic(node, vertex, dataCharacteristic));
+        }
+        if (dataCharacteristicsForwarded.isEmpty() && vertex.getAllIncomingDataCharacteristics()
+                .isEmpty()
+                && vertex.getAllOutgoingDataCharacteristics()
+                        .isEmpty()
+                && !(vertex instanceof UserPCMVertex<?>
+                        && ((AbstractUserAction) vertex.getReferencedElement()).getScenarioBehaviour_AbstractUserAction()
+                                .getUsageScenario_SenarioBehaviour() != null)) {
+            assignments.add(this.preserveControlFlow(node, vertex));
+        }
+        return assignments;
+    }
+
+    /**
+     * Creates an assignment that forwards the given data characteristics of the PCM vertex in the given DFD node
+     * @param node DFD node that should receive the created assignment
+     * @param vertex PCM vertex that determines the assignment behavior
+     * @param dataCharacteristic Data characteristic that is forwarded
+     * @return Returns an assignment that forwards the given data characteristic
+     */
+    private AbstractAssignment forwardCharacteristic(Node node, AbstractPCMVertex<?> vertex, DataCharacteristic dataCharacteristic) {
+        ForwardingAssignment assignment = datadictionaryFactory.eINSTANCE.createForwardingAssignment();
+        Pin inPin = node.getBehavior()
+                .getInPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(dataCharacteristic.getVariableName()))
+                .findAny()
+                .orElseThrow(() -> {
+                    logger.error("Cannot find required in-pin " + dataCharacteristic.getVariableName() + " at vertex with name " + vertex);
+                    return new NoSuchElementException();
+                });
+        Pin outPin = node.getBehavior()
+                .getOutPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(dataCharacteristic.getVariableName()))
+                .findAny()
+                .orElseThrow(() -> {
+                    logger.error("Cannot find required out-pin " + dataCharacteristic.getVariableName() + " at vertex with name " + vertex);
+                    return new NoSuchElementException();
+                });
+        assignment.getInputPins()
+                .add(inPin);
+        assignment.setOutputPin(outPin);
+        return assignment;
+    }
+
+    /**
+     * Preserves the control flow between converted vertices, by forwarding an empty value
+     * @param node DFD node that should reflect the control flow of the given PCM vertex
+     * @param vertex PCM vertex that dictates the control flow
+     * @return Returns an assignment that preserves the control flow between the elements in the conversion
+     */
+    private AbstractAssignment preserveControlFlow(Node node, AbstractPCMVertex<?> vertex) {
+        ForwardingAssignment assignment = datadictionaryFactory.eINSTANCE.createForwardingAssignment();
+        Pin inPin = node.getBehavior()
+                .getInPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(""))
+                .findAny()
+                .orElseThrow(() -> {
+                    logger.error("Cannot find required in-pin with empty name at vertex with name " + vertex);
+                    return new NoSuchElementException();
+                });
+        Pin outPin = node.getBehavior()
+                .getOutPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(""))
+                .findAny()
+                .orElseThrow(() -> {
+                    logger.error("Cannot find required out-pin with empty name at vertex with name " + vertex);
+                    return new NoSuchElementException();
+                });
+        assignment.getInputPins()
+                .add(inPin);
+        assignment.setOutputPin(outPin);
+        return assignment;
+    }
+
+    /**
+     * Processes the given variable characterization with the given converted DFD behavior and node with a given PCM vertex
+     * @param variableCharacterisation Variable characterization of the PCM vertex
+     * @param behaviour Resulting behavior of the DFD node
+     * @param node DFD node that is converted to
+     * @param vertex PCM vertex that is converted from
+     * @return Returns a list of all assignments that must be added to the DFD behavior to reflect the PCM variable
+     * characterization
+     */
+    private List<AbstractAssignment> processCharacterization(ConfidentialityVariableCharacterisation variableCharacterisation, Behavior behaviour,
+            Node node, AbstractPCMVertex<?> vertex) {
+        var leftHandSide = (LhsEnumCharacteristicReference) variableCharacterisation.getLhs();
+
+        EnumCharacteristicType characteristicType = (EnumCharacteristicType) leftHandSide.getCharacteristicType();
+        Literal characteristicValue = leftHandSide.getLiteral();
+        AbstractNamedReference reference = variableCharacterisation.getVariableUsage_VariableCharacterisation()
+                .getNamedReference__VariableUsage();
+
+        Term rightHandSide = variableCharacterisation.getRhs();
+
+        if (characteristicType == null && characteristicValue == null) {
+            return List.of(this.processFullForwardingAssignment(node, rightHandSide, reference));
+        } else if (characteristicValue == null) {
+            return this.processHalfForwardingAssignment(node, rightHandSide, reference, vertex, behaviour, characteristicType);
+        } else {
+            return List.of(this.processAssignment(node, rightHandSide, behaviour, reference, characteristicType, characteristicValue));
+        }
+    }
+
+    /**
+     * Processes a full forwarding assignment on a PCM vertex, resulting in a single DFD forwarding assignment
+     * @param node DFD node that is converted to
+     * @param rightHandSide Term that determines the origin of the forwarded variable
+     * @param reference Reference that determines the destination of the forwarded variable
+     * @return Returns an DFD assignment that reflects the PCM full forwarding assignment
+     */
+    private AbstractAssignment processFullForwardingAssignment(Node node, Term rightHandSide, AbstractNamedReference reference) {
+        if (!(rightHandSide instanceof NamedEnumCharacteristicReference namedEnumCharacteristicReference)) {
+            return datadictionaryFactory.eINSTANCE.createForwardingAssignment();
+        }
+        ForwardingAssignment assignment = datadictionaryFactory.eINSTANCE.createForwardingAssignment();
+        Pin outPin = node.getBehavior()
+                .getOutPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(reference.getReferenceName()))
+                .findAny()
+                .orElseThrow();
+        assignment.setOutputPin(outPin);
+        Optional<Pin> inPin = node.getBehavior()
+                .getInPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(namedEnumCharacteristicReference.getNamedReference()
+                                .getReferenceName())
+                        || it.getEntityName()
+                                .equals(""))
+                .findAny();
+        if (inPin.isPresent()) {
+            assignment.getInputPins()
+                    .add(inPin.get());
+        } else {
+            logger.warn("One StoEx references incoming data that is not incoming!");
+        }
+        return assignment;
+    }
+
+    /**
+     * Process a half forwarding assignment on a PCM vertex, resulting in multiple DFD assignments that model the assignment
+     * @param node DFD node that is converted to
+     * @param rightHandSide Term that determines the data characteristic origin
+     * @param reference Reference that determines the data characteristic destination
+     * @param vertex PCM vertex that has the given assignment
+     * @param behaviour DFD behavior that is converted to
+     * @param characteristicType PCM characteristic type that is forwarded
+     * @return Returns a list of abstract assignments that reflects the forwarding of all characteristic values of a given
+     * type
+     */
+    private List<AbstractAssignment> processHalfForwardingAssignment(Node node, Term rightHandSide, AbstractNamedReference reference,
+            AbstractPCMVertex<?> vertex, Behavior behaviour, EnumCharacteristicType characteristicType) {
+        List<AbstractAssignment> assignments = new ArrayList<>();
+        List<Literal> forwardedValues = characteristicType.getType()
+                .getLiterals();
+        for (Literal value : forwardedValues) {
+            Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
+            LabelType labelType = this.getOrCreateLabelType(characteristicType.getName());
+            Label label = this.getOrCreateDFDLabel(value.getName(), labelType);
+            assignment.getOutputLabels()
+                    .add(label);
+
+            Pin outPin = node.getBehavior()
+                    .getOutPin()
+                    .stream()
+                    .filter(it -> it.getEntityName()
+                            .equals(reference.getReferenceName()))
+                    .findAny()
+                    .orElseThrow();
+            assignment.setOutputPin(outPin);
+            org.dataflowanalysis.dfd.datadictionary.Term term = parseTerm(rightHandSide, dataDictionary, label);
+
+            assignment.setTerm(term);
+            if (rightHandSide instanceof NamedEnumCharacteristicReference namedEnumCharacteristicReference) {
+                Pin inPin = node.getBehavior()
+                        .getInPin()
+                        .stream()
+                        .filter(it -> it.getEntityName()
+                                .equals(namedEnumCharacteristicReference.getNamedReference()
+                                        .getReferenceName()))
+                        .findAny()
+                        .orElseThrow();
+                assignment.getInputPins()
+                        .add(inPin);
+            } else {
+                assignment.getInputPins()
+                        .addAll(behaviour.getInPin());
+            }
+            assignments.add(assignment);
+        }
+        return assignments;
+    }
+
+    /**
+     * Process an assignment on the given node with the given characteristic type and value as well as the pin
+     * @param node DFD node that is converted to
+     * @param rightHandSide Condition that reflects the value of the targeted data characteristic
+     * @param behaviour DFD behavior that is converted to
+     * @param reference Reference that determines the destination of the assignment
+     * @param characteristicType Characteristic type that is assigned to
+     * @param characteristicValue Characteristic value that is assigned to
+     * @return Returns an assignment that models the PCM behavior at the given vertex
+     */
+    private AbstractAssignment processAssignment(Node node, Term rightHandSide, Behavior behaviour, AbstractNamedReference reference,
+            EnumCharacteristicType characteristicType, Literal characteristicValue) {
+        Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
+        LabelType labelType = getOrCreateLabelType(characteristicType.getName());
+
+        Label label = getOrCreateDFDLabel(characteristicValue.getName(), labelType);
+        assignment.getOutputLabels()
+                .add(label);
+
+        Pin outPin = node.getBehavior()
+                .getOutPin()
+                .stream()
+                .filter(it -> it.getEntityName()
+                        .equals(reference.getReferenceName()))
+                .findAny()
+                .orElseThrow();
+        assignment.setOutputPin(outPin);
+        org.dataflowanalysis.dfd.datadictionary.Term term = parseTerm(rightHandSide, dataDictionary);
+        assignment.setTerm(term);
+        if (rightHandSide instanceof NamedEnumCharacteristicReference namedEnumCharacteristicReference) {
+            Pin inPin = node.getBehavior()
+                    .getInPin()
+                    .stream()
+                    .filter(it -> it.getEntityName()
+                            .equals(namedEnumCharacteristicReference.getNamedReference()
+                                    .getReferenceName()))
+                    .findAny()
+                    .orElseThrow();
+            assignment.getInputPins()
+                    .add(inPin);
+        } else {
+            assignment.getInputPins()
+                    .addAll(behaviour.getInPin());
+        }
+        return assignment;
+    }
+
+    /**
+     * Converts behavior from PCM Vertex to Node and adds it to the Data Dictionary
+     * @param pcmVertex the PCM Vertex
+     * @param node the DFD Node
+     * @param dataDictionary the Data Dictionary
+     */
+    public void convertBehavior(AbstractPCMVertex<?> pcmVertex, Node node, DataDictionary dataDictionary) {
+        List<ConfidentialityVariableCharacterisation> variableCharacterisations = this.getVariableCharacterizations(pcmVertex);
+
+        Behavior behaviour = node.getBehavior();
+        List<AbstractAssignment> assignments = this.getAssignments(pcmVertex, node);
+        for (ConfidentialityVariableCharacterisation variableCharacterization : variableCharacterisations) {
+            assignments.addAll(this.processCharacterization(variableCharacterization, behaviour, node, pcmVertex));
+        }
+        behaviour.getAssignment()
+                .clear();
+        behaviour.getAssignment()
+                .addAll(assignments);
+
+        behaviour.getOutPin()
+                .stream()
+                .forEach(pin -> {
+                    Assignment assignment = datadictionaryFactory.eINSTANCE.createAssignment();
+                    assignment.setEntityName("Dummy Assignment");
+                    assignment.getInputPins()
+                            .addAll(behaviour.getInPin());
+                    assignment.setOutputPin(pin);
+                    assignment.setTerm(datadictionaryFactory.eINSTANCE.createTRUE());
+                    behaviour.getAssignment()
+                            .add(assignment);
+                });
+    }
+
+    /**
+     * Parses a Term object into a corresponding Data Dictionary Term
+     * @param rightHandSide the Term object to parse
+     * @param dataDictionary the Data Dictionary
+     * @return the parsed Term
+     */
+    public org.dataflowanalysis.dfd.datadictionary.Term parseTerm(Term rightHandSide, DataDictionary dataDictionary, Label wildcardLabel) {
+        if (rightHandSide instanceof True) {
+            return datadictionaryFactory.eINSTANCE.createTRUE();
+        } else if (rightHandSide instanceof False) {
+            NOT term = datadictionaryFactory.eINSTANCE.createNOT();
+            term.setNegatedTerm(datadictionaryFactory.eINSTANCE.createTRUE());
+            return term;
+        } else if (rightHandSide instanceof Or or) {
+            OR term = datadictionaryFactory.eINSTANCE.createOR();
+            term.getTerms()
+                    .add(parseTerm(or.getLeft(), dataDictionary, wildcardLabel));
+            term.getTerms()
+                    .add(parseTerm(or.getRight(), dataDictionary, wildcardLabel));
+            return term;
+        } else if (rightHandSide instanceof And and) {
+            AND term = datadictionaryFactory.eINSTANCE.createAND();
+            term.getTerms()
+                    .add(parseTerm(and.getLeft(), dataDictionary, wildcardLabel));
+            term.getTerms()
+                    .add(parseTerm(and.getRight(), dataDictionary, wildcardLabel));
+            return term;
+        } else if (rightHandSide instanceof NamedEnumCharacteristicReference characteristicReference) {
+            LabelReference term = datadictionaryFactory.eINSTANCE.createLabelReference();
+            LabelType labelType = this.getOrCreateLabelType(characteristicReference.getCharacteristicType()
+                    .getName());
+            if (characteristicReference.getLiteral() != null) {
+                Label label = this.getOrCreateDFDLabel(characteristicReference.getLiteral()
+                        .getName(), labelType);
+                term.setLabel(label);
+            } else {
+                term.setLabel(wildcardLabel);
+            }
+            return term;
+        }
+        throw new IllegalStateException();
+    }
+
+    /**
+     * Parses a Term object into a corresponding Data Dictionary Term
+     * @param rightHandSide the Term object to parse
+     * @param dataDictionary the Data Dictionary
+     * @return the parsed Term
+     */
+    public org.dataflowanalysis.dfd.datadictionary.Term parseTerm(Term rightHandSide, DataDictionary dataDictionary) {
+        return this.parseTerm(rightHandSide, dataDictionary, null);
+    }
+
+    public Map<AbstractPCMVertex<?>, Node> getDfdNodeMap() {
+        return dfdNodeMap;
+    }
+
+    public Map<AbstractPCMVertex<?>, AbstractTransposeFlowGraph> getPcmFlowMap() {
+        return pcmFlowMap;
+    }
 }

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/webdfd/Annotation.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/webdfd/Annotation.java
@@ -1,7 +1,5 @@
 package org.dataflowanalysis.converter.webdfd;
 
-
-
 public record Annotation(String message, String icon, String color) {
-	
+
 }

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/webdfd/Child.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/webdfd/Child.java
@@ -17,15 +17,16 @@ import java.util.List;
 
 // The WebEditor is susceptible to changes, and to accommodate new fields, we disregard any unseen fields
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Child(String text, List<WebEditorLabel> labels, List<Port> ports, String id, String type, String sourceId, String targetId, Annotation annotation,
-        List<Child> children) {
+public record Child(String text, List<WebEditorLabel> labels, List<Port> ports, String id, String type, String sourceId, String targetId,
+        Annotation annotation, List<Child> children) {
 
     /**
      * Overrides equals method to support child type specific equality checks.
      */
-	@Override
+    @Override
     public boolean equals(Object otherObject) {
-		if (!(otherObject instanceof Child other)) return false;
+        if (!(otherObject instanceof Child other))
+            return false;
         if (!this.type.equals(other.type)) {
             return false;
         } else if (this.type.split(":")[0].equals("node")) {

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/webdfd/WebEditorDfd.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/webdfd/WebEditorDfd.java
@@ -1,9 +1,8 @@
 package org.dataflowanalysis.converter.webdfd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Comparator;
 import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Represents a web editor data flow diagram

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/AnnotationsTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/AnnotationsTest.java
@@ -6,9 +6,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.function.Predicate;
-
+import java.util.stream.Collectors;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.converter.DataFlowDiagramAndDictionary;
@@ -37,113 +36,171 @@ public class AnnotationsTest {
     private DataDictionary dataDictionary;
     private Node b;
     private LabelType type;
-	
-	@BeforeEach
-    public void init() {    	
-    	dataFlowDiagramConverter = new DataFlowDiagramConverter();
+
+    @BeforeEach
+    public void init() {
+        dataFlowDiagramConverter = new DataFlowDiagramConverter();
         dataFlowDiagram = dfdFactory.createDataFlowDiagram();
         dataDictionary = ddFactory.createDataDictionary();
-        
+
         Node a = createNode("a");
-    	b = createNode("b");
-    	Node c = createNode("c");
-    	createFlow(a, b, null, null, "a2b");
-    	createFlow(b, c, null, null, "b2c");
-    	
-    	type = ddFactory.createLabelType();
-    	type.setEntityName("type");
-    	Label label = ddFactory.createLabel();
-    	label.setEntityName("value");
-    	type.getLabel().add(label);
-    	dataDictionary.getLabelTypes().add(type);
-    	
-    	Assignment assignment = ddFactory.createAssignment();
-    	assignment.setOutputPin(a.getBehavior().getOutPin().get(0));
-    	assignment.setTerm(ddFactory.createTRUE());
-    	assignment.getOutputLabels().add(label);
-    	a.getBehavior().getAssignment().add(assignment);
-    	
-    	ForwardingAssignment forwardingAssignment = ddFactory.createForwardingAssignment();
-    	forwardingAssignment.getInputPins().addAll(b.getBehavior().getInPin());
-    	forwardingAssignment.setOutputPin(b.getBehavior().getOutPin().get(0));
-    	b.getBehavior().getAssignment().add(forwardingAssignment);
+        b = createNode("b");
+        Node c = createNode("c");
+        createFlow(a, b, null, null, "a2b");
+        createFlow(b, c, null, null, "b2c");
+
+        type = ddFactory.createLabelType();
+        type.setEntityName("type");
+        Label label = ddFactory.createLabel();
+        label.setEntityName("value");
+        type.getLabel()
+                .add(label);
+        dataDictionary.getLabelTypes()
+                .add(type);
+
+        Assignment assignment = ddFactory.createAssignment();
+        assignment.setOutputPin(a.getBehavior()
+                .getOutPin()
+                .get(0));
+        assignment.setTerm(ddFactory.createTRUE());
+        assignment.getOutputLabels()
+                .add(label);
+        a.getBehavior()
+                .getAssignment()
+                .add(assignment);
+
+        ForwardingAssignment forwardingAssignment = ddFactory.createForwardingAssignment();
+        forwardingAssignment.getInputPins()
+                .addAll(b.getBehavior()
+                        .getInPin());
+        forwardingAssignment.setOutputPin(b.getBehavior()
+                .getOutPin()
+                .get(0));
+        b.getBehavior()
+                .getAssignment()
+                .add(forwardingAssignment);
     }
-	
-	@Test
-	public void testPropagatedLabelsAnnotation() {
-		Map<String, Annotation> nodeNameToAnnotationMap = new HashMap<>();
-		var webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
-		webDfd.model().children().stream().filter(child -> child.type().startsWith("node")).forEach(node -> {
-			nodeNameToAnnotationMap.put(node.text(), node.annotation());
-		});
-		assertEquals("PropagatedLabels:type.value", nodeNameToAnnotationMap.get("a").message().replace(" ", "").replace("\n", ""));
-		assertEquals("#FFFFFF", nodeNameToAnnotationMap.get("a").color());
-		assertEquals("tag", nodeNameToAnnotationMap.get("a").icon());
-		assertEquals("PropagatedLabels:type.value", nodeNameToAnnotationMap.get("b").message().replace(" ", "").replace("\n", ""));
-		assertEquals(null, nodeNameToAnnotationMap.get("c"));
-	}
-	
-	@Test
-	public void testViolationsAnnotation() {
-    	Label label = ddFactory.createLabel();
-    	label.setEntityName("violation");
-    	type.getLabel().add(label);
-		
-    	b.getProperties().add(label);
-    	List<Predicate<? super AbstractVertex<?>>> conditions = new ArrayList<>();
-    	conditions.add(this::condition);
-		
-		Map<String, Annotation> nodeNameToAnnotationMap = new HashMap<>();
-		var webDfd = dataFlowDiagramConverter.dfdToWebAndAnalyzeAndAnnotate(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary), conditions);
-		webDfd.model().children().stream().filter(child -> child.type().startsWith("node")).forEach(node -> {
-			nodeNameToAnnotationMap.put(node.text(), node.annotation());
-		});
-		assertEquals("PropagatedLabels:type.value", nodeNameToAnnotationMap.get("a").message().replace(" ", "").replace("\n", ""));		
-		assertEquals("PropagatedLabels:type.valueViolation:Constraint0violated.", nodeNameToAnnotationMap.get("b").message().replace(" ", "").replace("\n", ""));
-		assertEquals("#ff0000", nodeNameToAnnotationMap.get("b").color());
-		assertEquals("bolt", nodeNameToAnnotationMap.get("b").icon());
-		assertEquals(null, nodeNameToAnnotationMap.get("c"));
-	}
-	
-	private boolean condition(AbstractVertex<?> node) {
+
+    @Test
+    public void testPropagatedLabelsAnnotation() {
+        Map<String, Annotation> nodeNameToAnnotationMap = new HashMap<>();
+        var webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
+        webDfd.model()
+                .children()
+                .stream()
+                .filter(child -> child.type()
+                        .startsWith("node"))
+                .forEach(node -> {
+                    nodeNameToAnnotationMap.put(node.text(), node.annotation());
+                });
+        assertEquals("PropagatedLabels:type.value", nodeNameToAnnotationMap.get("a")
+                .message()
+                .replace(" ", "")
+                .replace("\n", ""));
+        assertEquals("#FFFFFF", nodeNameToAnnotationMap.get("a")
+                .color());
+        assertEquals("tag", nodeNameToAnnotationMap.get("a")
+                .icon());
+        assertEquals("PropagatedLabels:type.value", nodeNameToAnnotationMap.get("b")
+                .message()
+                .replace(" ", "")
+                .replace("\n", ""));
+        assertEquals(null, nodeNameToAnnotationMap.get("c"));
+    }
+
+    @Test
+    public void testViolationsAnnotation() {
+        Label label = ddFactory.createLabel();
+        label.setEntityName("violation");
+        type.getLabel()
+                .add(label);
+
+        b.getProperties()
+                .add(label);
+        List<Predicate<? super AbstractVertex<?>>> conditions = new ArrayList<>();
+        conditions.add(this::condition);
+
+        Map<String, Annotation> nodeNameToAnnotationMap = new HashMap<>();
+        var webDfd = dataFlowDiagramConverter.dfdToWebAndAnalyzeAndAnnotate(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary),
+                conditions);
+        webDfd.model()
+                .children()
+                .stream()
+                .filter(child -> child.type()
+                        .startsWith("node"))
+                .forEach(node -> {
+                    nodeNameToAnnotationMap.put(node.text(), node.annotation());
+                });
+        assertEquals("PropagatedLabels:type.value", nodeNameToAnnotationMap.get("a")
+                .message()
+                .replace(" ", "")
+                .replace("\n", ""));
+        assertEquals("PropagatedLabels:type.valueViolation:Constraint0violated.", nodeNameToAnnotationMap.get("b")
+                .message()
+                .replace(" ", "")
+                .replace("\n", ""));
+        assertEquals("#ff0000", nodeNameToAnnotationMap.get("b")
+                .color());
+        assertEquals("bolt", nodeNameToAnnotationMap.get("b")
+                .icon());
+        assertEquals(null, nodeNameToAnnotationMap.get("c"));
+    }
+
+    private boolean condition(AbstractVertex<?> node) {
         List<String> properties = node.getVertexCharacteristics("type")
                 .stream()
                 .map(CharacteristicValue::getValueName)
                 .toList();
-        List<String> incomingLabeList = node.getAllIncomingDataCharacteristics().stream().flatMap(it -> it.getAllCharacteristics().stream().map(c -> c.getValueName())).collect(Collectors.toList());
-        
+        List<String> incomingLabeList = node.getAllIncomingDataCharacteristics()
+                .stream()
+                .flatMap(it -> it.getAllCharacteristics()
+                        .stream()
+                        .map(c -> c.getValueName()))
+                .collect(Collectors.toList());
+
         return properties.contains("violation") && incomingLabeList.contains("value");
-    }     
-	
-	private Node createNode(String name) {
-    	Node node = dfdFactory.createProcess();
-    	node.setEntityName(name);
-    	Behavior behaviour = ddFactory.createBehavior();
-    	behaviour.setEntityName(name + "_behaviour");
-    	node.setBehavior(behaviour);
-    	dataFlowDiagram.getNodes().add(node);
-    	dataDictionary.getBehavior().add(behaviour);
-    	return node;
     }
-    
+
+    private Node createNode(String name) {
+        Node node = dfdFactory.createProcess();
+        node.setEntityName(name);
+        Behavior behaviour = ddFactory.createBehavior();
+        behaviour.setEntityName(name + "_behaviour");
+        node.setBehavior(behaviour);
+        dataFlowDiagram.getNodes()
+                .add(node);
+        dataDictionary.getBehavior()
+                .add(behaviour);
+        return node;
+    }
+
     private Flow createFlow(Node sourceNode, Node destinationNode, Pin sourcePin, Pin destinationPin, String name) {
-    	Flow flow = dfdFactory.createFlow();
-    	flow.setDestinationNode(destinationNode);
-    	flow.setSourceNode(sourceNode);
-    	if (sourcePin == null) {
-    		sourcePin = ddFactory.createPin();
-    		sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior().getOutPin().size());
-    		sourceNode.getBehavior().getOutPin().add(sourcePin);
-    	}
-    	if (destinationPin == null) {
-    		destinationPin = ddFactory.createPin();
-    		destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior().getInPin().size());
-    		destinationNode.getBehavior().getInPin().add(destinationPin);
-    	}
-    	flow.setDestinationPin(destinationPin);
-    	flow.setSourcePin(sourcePin);
-    	flow.setEntityName(name);
-    	dataFlowDiagram.getFlows().add(flow);
-    	return flow;
+        Flow flow = dfdFactory.createFlow();
+        flow.setDestinationNode(destinationNode);
+        flow.setSourceNode(sourceNode);
+        if (sourcePin == null) {
+            sourcePin = ddFactory.createPin();
+            sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior()
+                    .getOutPin()
+                    .size());
+            sourceNode.getBehavior()
+                    .getOutPin()
+                    .add(sourcePin);
+        }
+        if (destinationPin == null) {
+            destinationPin = ddFactory.createPin();
+            destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior()
+                    .getInPin()
+                    .size());
+            destinationNode.getBehavior()
+                    .getInPin()
+                    .add(destinationPin);
+        }
+        flow.setDestinationPin(destinationPin);
+        flow.setSourcePin(sourcePin);
+        flow.setEntityName(name);
+        dataFlowDiagram.getFlows()
+                .add(flow);
+        return flow;
     }
 }

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/BehaviorTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/BehaviorTest.java
@@ -5,17 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.dataflowanalysis.converter.BehaviorConverter;
 import org.dataflowanalysis.converter.DataFlowDiagramAndDictionary;
 import org.dataflowanalysis.converter.DataFlowDiagramConverter;
 import org.dataflowanalysis.converter.webdfd.Child;
 import org.dataflowanalysis.converter.webdfd.WebEditorDfd;
+import org.dataflowanalysis.dfd.datadictionary.*;
 import org.dataflowanalysis.dfd.datadictionary.Behavior;
 import org.dataflowanalysis.dfd.datadictionary.Pin;
 import org.dataflowanalysis.dfd.datadictionary.datadictionaryFactory;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
-import org.dataflowanalysis.dfd.datadictionary.*;
 import org.dataflowanalysis.dfd.dataflowdiagram.Flow;
 import org.dataflowanalysis.dfd.dataflowdiagram.Node;
 import org.dataflowanalysis.dfd.dataflowdiagram.dataflowdiagramFactory;
@@ -34,8 +33,8 @@ public class BehaviorTest {
     private DataDictionary dataDictionary;
 
     @BeforeEach
-    public void init() {    	
-    	dataFlowDiagramConverter = new DataFlowDiagramConverter();
+    public void init() {
+        dataFlowDiagramConverter = new DataFlowDiagramConverter();
         dataFlowDiagram = dfdFactory.createDataFlowDiagram();
         dataDictionary = ddFactory.createDataDictionary();
         behaviourConverter = new BehaviorConverter(dataDictionary);
@@ -49,152 +48,212 @@ public class BehaviorTest {
             "!((TypeA.ValueA && (TypeB.ValueB || !TypeC.ValueC)) || (!(TypeD.ValueD && TypeE.ValueE) && (TypeF.ValueF || TypeG.ValueG)))"})
     @DisplayName("Test Behavior Conversion")
     void testBehaviorConversion(String behavior) {
-    	for (char c = 'A'; c <= 'G'; c++) {
-    		LabelType type = ddFactory.createLabelType();
-        	type.setEntityName("Type" + c);
-        	Label label = ddFactory.createLabel();
-        	label.setEntityName("Value" + c);
-        	type.getLabel().add(label);
-        	dataDictionary.getLabelTypes().add(type);
-    	}
+        for (char c = 'A'; c <= 'G'; c++) {
+            LabelType type = ddFactory.createLabelType();
+            type.setEntityName("Type" + c);
+            Label label = ddFactory.createLabel();
+            label.setEntityName("Value" + c);
+            type.getLabel()
+                    .add(label);
+            dataDictionary.getLabelTypes()
+                    .add(type);
+        }
         assertEquals(behavior, behaviourConverter.termToString(behaviourConverter.stringToTerm(behavior)));
     }
-    
-    
+
     @Test
     void testAssignmentConversion() {
-    	Node a = createNode("a");
-    	Node b = createNode("b");
-    	Node c = createNode("c");
-    	createFlow(a, b, null, null, "a2b");
-    	createFlow(b, c, null, null, "b2c");
-    	Assignment assignment = ddFactory.createAssignment();
-    	assignment.getInputPins().addAll(b.getBehavior().getInPin());
-    	assignment.setOutputPin(b.getBehavior().getOutPin().get(0));
-    	NOT not = ddFactory.createNOT();
-    	AND and = ddFactory.createAND();
-    	TRUE trueTerm = ddFactory.createTRUE();
-    	LabelReference ref = ddFactory.createLabelReference();
-    	
-    	LabelType type = ddFactory.createLabelType();
-    	type.setEntityName("type");
-    	Label label = ddFactory.createLabel();
-    	label.setEntityName("value");
-    	type.getLabel().add(label);
-    	Label label2 = ddFactory.createLabel();
-    	label2.setEntityName("value2");
-    	type.getLabel().add(label2);
-    	dataDictionary.getLabelTypes().add(type);
-    	    	
-    	ref.setLabel(label);
-    	
-    	and.getTerms().add(ref);
-    	and.getTerms().add(trueTerm);
-    	
-    	not.setNegatedTerm(and);
-    	
-    	assignment.setTerm(not);
-    	
-    	assignment.getOutputLabels().add(label);
-    	assignment.getOutputLabels().add(label2);
-    	
-    	b.getBehavior().getAssignment().add(assignment);
-    	
-    	var setAssignment = ddFactory.createSetAssignment();
-    	setAssignment.getOutputLabels().add(label);
-    	setAssignment.setOutputPin(b.getBehavior().getOutPin().get(0));
-    	b.getBehavior().getAssignment().add(setAssignment);
-    	
-    	var unsetAssignment = ddFactory.createUnsetAssignment();
-    	unsetAssignment.getOutputLabels().add(label2);
-    	unsetAssignment.setOutputPin(b.getBehavior().getOutPin().get(0));
-    	b.getBehavior().getAssignment().add(unsetAssignment);
-    	
-    	var webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
-    	
-    	testAssignment(webDfd, "b", List.of("assign type.value,type.value2 if !(type.value && TRUE) from a2b",
-    			"set type.value", "unset type.value2"));    	
+        Node a = createNode("a");
+        Node b = createNode("b");
+        Node c = createNode("c");
+        createFlow(a, b, null, null, "a2b");
+        createFlow(b, c, null, null, "b2c");
+        Assignment assignment = ddFactory.createAssignment();
+        assignment.getInputPins()
+                .addAll(b.getBehavior()
+                        .getInPin());
+        assignment.setOutputPin(b.getBehavior()
+                .getOutPin()
+                .get(0));
+        NOT not = ddFactory.createNOT();
+        AND and = ddFactory.createAND();
+        TRUE trueTerm = ddFactory.createTRUE();
+        LabelReference ref = ddFactory.createLabelReference();
+
+        LabelType type = ddFactory.createLabelType();
+        type.setEntityName("type");
+        Label label = ddFactory.createLabel();
+        label.setEntityName("value");
+        type.getLabel()
+                .add(label);
+        Label label2 = ddFactory.createLabel();
+        label2.setEntityName("value2");
+        type.getLabel()
+                .add(label2);
+        dataDictionary.getLabelTypes()
+                .add(type);
+
+        ref.setLabel(label);
+
+        and.getTerms()
+                .add(ref);
+        and.getTerms()
+                .add(trueTerm);
+
+        not.setNegatedTerm(and);
+
+        assignment.setTerm(not);
+
+        assignment.getOutputLabels()
+                .add(label);
+        assignment.getOutputLabels()
+                .add(label2);
+
+        b.getBehavior()
+                .getAssignment()
+                .add(assignment);
+
+        var setAssignment = ddFactory.createSetAssignment();
+        setAssignment.getOutputLabels()
+                .add(label);
+        setAssignment.setOutputPin(b.getBehavior()
+                .getOutPin()
+                .get(0));
+        b.getBehavior()
+                .getAssignment()
+                .add(setAssignment);
+
+        var unsetAssignment = ddFactory.createUnsetAssignment();
+        unsetAssignment.getOutputLabels()
+                .add(label2);
+        unsetAssignment.setOutputPin(b.getBehavior()
+                .getOutPin()
+                .get(0));
+        b.getBehavior()
+                .getAssignment()
+                .add(unsetAssignment);
+
+        var webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
+
+        testAssignment(webDfd, "b",
+                List.of("assign type.value,type.value2 if !(type.value && TRUE) from a2b", "set type.value", "unset type.value2"));
     }
-    
+
     @Test
     void testFlowNameAndPinDelimiter() {
-    	Node a = createNode("a");
-    	Node b = createNode("b");
-    	Node c = createNode("c");
-    	Node d = createNode("d");
-    	
-    	createFlow(a, c, null, null, "a2c");
-    	Pin destinationPin = c.getBehavior().getInPin().get(0);
-    	createFlow(b, c, null, destinationPin, "b2c");
-    	
-    	Pin c_out = ddFactory.createPin();
-    	ForwardingAssignment assignment = ddFactory.createForwardingAssignment();
-    	assignment.setOutputPin(c_out);
-    	assignment.getInputPins().add(c.getBehavior().getInPin().get(0));
-    	c.getBehavior().getOutPin().add(c_out);
-    	c.getBehavior().getAssignment().add(assignment);
-    	
-    	createFlow(c, d, c_out, null, "c2d");
-    	
-    	var webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
-    	
-    	testAssignment(webDfd, "c", List.of("forward a2c|b2c"));    	
-    	
-    	Node z = createNode("z");
-    	var newFlow = createFlow(z, c, null, null, "z2c");
-    	assignment.getInputPins().add(newFlow.getDestinationPin());
-    	
-    	//prevents exception before analysis hotfix merge, Can be deleted after
-    	Node y = createNode("y");
-    	createFlow(y, z, null, null, "y2z");
-    	ForwardingAssignment assignment2 = ddFactory.createForwardingAssignment();
-    	assignment2.setOutputPin(z.getBehavior().getOutPin().get(0));
-    	assignment2.getInputPins().add(z.getBehavior().getInPin().get(0));
-    	z.getBehavior().getAssignment().add(assignment2);
-    	
-    	webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
-    	
-    	testAssignment(webDfd, "c", List.of("forward a2c|b2c,z2c"));    	
+        Node a = createNode("a");
+        Node b = createNode("b");
+        Node c = createNode("c");
+        Node d = createNode("d");
+
+        createFlow(a, c, null, null, "a2c");
+        Pin destinationPin = c.getBehavior()
+                .getInPin()
+                .get(0);
+        createFlow(b, c, null, destinationPin, "b2c");
+
+        Pin c_out = ddFactory.createPin();
+        ForwardingAssignment assignment = ddFactory.createForwardingAssignment();
+        assignment.setOutputPin(c_out);
+        assignment.getInputPins()
+                .add(c.getBehavior()
+                        .getInPin()
+                        .get(0));
+        c.getBehavior()
+                .getOutPin()
+                .add(c_out);
+        c.getBehavior()
+                .getAssignment()
+                .add(assignment);
+
+        createFlow(c, d, c_out, null, "c2d");
+
+        var webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
+
+        testAssignment(webDfd, "c", List.of("forward a2c|b2c"));
+
+        Node z = createNode("z");
+        var newFlow = createFlow(z, c, null, null, "z2c");
+        assignment.getInputPins()
+                .add(newFlow.getDestinationPin());
+
+        // prevents exception before analysis hotfix merge, Can be deleted after
+        Node y = createNode("y");
+        createFlow(y, z, null, null, "y2z");
+        ForwardingAssignment assignment2 = ddFactory.createForwardingAssignment();
+        assignment2.setOutputPin(z.getBehavior()
+                .getOutPin()
+                .get(0));
+        assignment2.getInputPins()
+                .add(z.getBehavior()
+                        .getInPin()
+                        .get(0));
+        z.getBehavior()
+                .getAssignment()
+                .add(assignment2);
+
+        webDfd = dataFlowDiagramConverter.dfdToWeb(new DataFlowDiagramAndDictionary(dataFlowDiagram, dataDictionary));
+
+        testAssignment(webDfd, "c", List.of("forward a2c|b2c,z2c"));
     }
-    
+
     private void testAssignment(WebEditorDfd webDFD, String nodeName, List<String> assignments) {
-    	for (Child child : webDFD.model().children()) {
-    		if (child.type().startsWith("node") && child.text().equals(nodeName)) {
-    			List<String> assignmentsFromString = child.ports().stream().flatMap(s -> ((s.behavior() != null) ? List.of(s.behavior().split("\n")) : new ArrayList<String>()).stream()).collect(Collectors.toList());
-    			assertEquals(assignments, assignmentsFromString);
-    		}
-    	}
+        for (Child child : webDFD.model()
+                .children()) {
+            if (child.type()
+                    .startsWith("node")
+                    && child.text()
+                            .equals(nodeName)) {
+                List<String> assignmentsFromString = child.ports()
+                        .stream()
+                        .flatMap(s -> ((s.behavior() != null) ? List.of(s.behavior()
+                                .split("\n")) : new ArrayList<String>()).stream())
+                        .collect(Collectors.toList());
+                assertEquals(assignments, assignmentsFromString);
+            }
+        }
     }
-    
+
     private Node createNode(String name) {
-    	Node node = dfdFactory.createProcess();
-    	node.setEntityName(name);
-    	Behavior behaviour = ddFactory.createBehavior();
-    	behaviour.setEntityName(name + "_behaviour");
-    	node.setBehavior(behaviour);
-    	dataFlowDiagram.getNodes().add(node);
-    	dataDictionary.getBehavior().add(behaviour);
-    	return node;
+        Node node = dfdFactory.createProcess();
+        node.setEntityName(name);
+        Behavior behaviour = ddFactory.createBehavior();
+        behaviour.setEntityName(name + "_behaviour");
+        node.setBehavior(behaviour);
+        dataFlowDiagram.getNodes()
+                .add(node);
+        dataDictionary.getBehavior()
+                .add(behaviour);
+        return node;
     }
-    
+
     private Flow createFlow(Node sourceNode, Node destinationNode, Pin sourcePin, Pin destinationPin, String name) {
-    	Flow flow = dfdFactory.createFlow();
-    	flow.setDestinationNode(destinationNode);
-    	flow.setSourceNode(sourceNode);
-    	if (sourcePin == null) {
-    		sourcePin = ddFactory.createPin();
-    		sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior().getOutPin().size());
-    		sourceNode.getBehavior().getOutPin().add(sourcePin);
-    	}
-    	if (destinationPin == null) {
-    		destinationPin = ddFactory.createPin();
-    		destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior().getInPin().size());
-    		destinationNode.getBehavior().getInPin().add(destinationPin);
-    	}
-    	flow.setDestinationPin(destinationPin);
-    	flow.setSourcePin(sourcePin);
-    	flow.setEntityName(name);
-    	dataFlowDiagram.getFlows().add(flow);
-    	return flow;
+        Flow flow = dfdFactory.createFlow();
+        flow.setDestinationNode(destinationNode);
+        flow.setSourceNode(sourceNode);
+        if (sourcePin == null) {
+            sourcePin = ddFactory.createPin();
+            sourcePin.setEntityName(sourceNode.getEntityName() + "_out_" + sourceNode.getBehavior()
+                    .getOutPin()
+                    .size());
+            sourceNode.getBehavior()
+                    .getOutPin()
+                    .add(sourcePin);
+        }
+        if (destinationPin == null) {
+            destinationPin = ddFactory.createPin();
+            destinationPin.setEntityName(destinationNode.getEntityName() + "_in_" + destinationNode.getBehavior()
+                    .getInPin()
+                    .size());
+            destinationNode.getBehavior()
+                    .getInPin()
+                    .add(destinationPin);
+        }
+        flow.setDestinationPin(destinationPin);
+        flow.setSourcePin(sourcePin);
+        flow.setEntityName(name);
+        dataFlowDiagram.getFlows()
+                .add(flow);
+        return flow;
     }
 }

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/PCMTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/PCMTest.java
@@ -9,29 +9,25 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.HashSet;
 import java.util.stream.Collectors;
-
 import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
-import org.dataflowanalysis.analysis.pcm.core.CallReturnBehavior;
-import org.dataflowanalysis.converter.DataFlowDiagramConverter;
-import org.dataflowanalysis.converter.PCMConverter;
-import org.dataflowanalysis.examplemodels.Activator;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
-import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.simple.DFDSimpleTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
+import org.dataflowanalysis.converter.DataFlowDiagramConverter;
+import org.dataflowanalysis.converter.PCMConverter;
 import org.dataflowanalysis.dfd.datadictionary.AND;
 import org.dataflowanalysis.dfd.datadictionary.Assignment;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
@@ -40,36 +36,37 @@ import org.dataflowanalysis.dfd.datadictionary.LabelReference;
 import org.dataflowanalysis.dfd.datadictionary.LabelType;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
 import org.dataflowanalysis.dfd.dataflowdiagram.Node;
+import org.dataflowanalysis.examplemodels.Activator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class PCMTest extends ConverterTest{
+public class PCMTest extends ConverterTest {
     @Test
     @DisplayName("Test PCM2DFD TravelPlanner")
     public void travelToDfd() {
         testSpecificModel("TravelPlanner", "travelPlanner", TEST_MODELS, "tp.json", this::travelPlannerCondition);
     }
-	
-	@Test
+
+    @Test
     @DisplayName("Test PCM2DFD MaaS")
     public void maasToDfd() {
         testSpecificModel("MaaS_Ticket_System_base", "MaaS", TEST_MODELS, "maas.json", this::maasCondition);
     }
-	
-	@Test
+
+    @Test
     @DisplayName("Test PCM2DFD CWA")
     public void cwaToDfd() {
         testSpecificModel("CoronaWarnApp", "default", TEST_MODELS, "cwa.json", null);
     }
-	
-	@Test
-	@DisplayName("Test PCM2DFD TravelPlanner Behavior")
-	public void testTravelPlannerBehavior() {
-		final var usageModelPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.usagemodel")
+
+    @Test
+    @DisplayName("Test PCM2DFD TravelPlanner Behavior")
+    public void testTravelPlannerBehavior() {
+        final var usageModelPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.usagemodel")
                 .toString();
         final var allocationPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.allocation")
                 .toString();
-        final var nodeCharPath = Paths.get("casestudies", "TravelPlanner",  "travelPlanner.nodecharacteristics")
+        final var nodeCharPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.nodecharacteristics")
                 .toString();
 
         DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
@@ -79,53 +76,86 @@ public class PCMTest extends ConverterTest{
                 .useAllocationModel(allocationPath)
                 .useNodeCharacteristicsModel(nodeCharPath)
                 .build();
-        
+
         analysis.setLoggerLevel(Level.ALL);
 
         analysis.initializeAnalysis();
         var flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
 
-       	List<AbstractPCMVertex<?>> vertices = new ArrayList<>();
+        List<AbstractPCMVertex<?>> vertices = new ArrayList<>();
         for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraph.getTransposeFlowGraphs()) {
             for (AbstractVertex<?> abstractVertex : transposeFlowGraph.getVertices()) {
-            	AbstractPCMVertex<?> v = (AbstractPCMVertex<?>) abstractVertex;
-               vertices.add(v);
+                AbstractPCMVertex<?> v = (AbstractPCMVertex<?>) abstractVertex;
+                vertices.add(v);
             }
         }
-        
+
         var dfd = new PCMConverter().pcmToDFD(TEST_MODELS, usageModelPath, allocationPath, nodeCharPath, Activator.class);
-        
+
         // Assignment: flights.*.* := RETURN.*.*
-        var readFlightsFromDB = dfd.dataFlowDiagram().getNodes().stream()
-        		.filter(it -> it.getId().equals("_x32bcPViEeuMKba1Qn68bg_1"))
-        		.findAny().orElseThrow();
-        assertTrue(readFlightsFromDB.getBehavior().getAssignment().stream()
-        		.filter(ForwardingAssignment.class::isInstance)
-        		.filter(it -> ((ForwardingAssignment)it).getInputPins().size() == 1)
-        		.filter(it -> ((ForwardingAssignment)it).getInputPins().get(0).getEntityName().equals("RETURN"))
-        		.anyMatch(it -> it.getOutputPin().getEntityName().equals("flights")));
-        
+        var readFlightsFromDB = dfd.dataFlowDiagram()
+                .getNodes()
+                .stream()
+                .filter(it -> it.getId()
+                        .equals("_x32bcPViEeuMKba1Qn68bg_1"))
+                .findAny()
+                .orElseThrow();
+        assertTrue(readFlightsFromDB.getBehavior()
+                .getAssignment()
+                .stream()
+                .filter(ForwardingAssignment.class::isInstance)
+                .filter(it -> ((ForwardingAssignment) it).getInputPins()
+                        .size() == 1)
+                .filter(it -> ((ForwardingAssignment) it).getInputPins()
+                        .get(0)
+                        .getEntityName()
+                        .equals("RETURN"))
+                .anyMatch(it -> it.getOutputPin()
+                        .getEntityName()
+                        .equals("flights")));
+
         // Assignment: RETURN.GrantedRoles.* := query.GrantedRoles.* & flight.GrantedRoles.*
-        var selectFlightsBasedOnQuery = dfd.dataFlowDiagram().getNodes().stream()
-        		.filter(it -> it.getId().equals("_2AAjoPViEeuMKba1Qn68bg"))
-        		.findAny().orElseThrow();
-        assertEquals(2, selectFlightsBasedOnQuery.getBehavior().getAssignment().stream()
-        		.filter(Assignment.class::isInstance)
-        		.map(Assignment.class::cast)
-        		.filter(it -> it.getOutputPin().getEntityName().equals("RETURN"))
-        		.filter(it -> it.getOutputLabels().size() == 1)
-        		.filter(it -> ((LabelType) it.getOutputLabels().get(0).eContainer()).getEntityName().equals("GrantedRoles"))
-        		.map(it -> it.getTerm())
-        		.filter(AND.class::isInstance)
-        		.map(AND.class::cast)
-        		.filter(it -> it.getTerms().size() == 2)
-        		.filter(it -> ((LabelType)((LabelReference) it.getTerms().get(0)).getLabel().eContainer()).getEntityName().equals("GrantedRoles"))
-        		.filter(it -> ((LabelType)((LabelReference) it.getTerms().get(1)).getLabel().eContainer()).getEntityName().equals("GrantedRoles"))
-        		.toList().size());
-	}
-    
-    private void testSpecificModel(String inputModel, String inputFile, String modelLocation, String webTarget, Predicate<AbstractVertex<?>> constraint) {
+        var selectFlightsBasedOnQuery = dfd.dataFlowDiagram()
+                .getNodes()
+                .stream()
+                .filter(it -> it.getId()
+                        .equals("_2AAjoPViEeuMKba1Qn68bg"))
+                .findAny()
+                .orElseThrow();
+        assertEquals(2, selectFlightsBasedOnQuery.getBehavior()
+                .getAssignment()
+                .stream()
+                .filter(Assignment.class::isInstance)
+                .map(Assignment.class::cast)
+                .filter(it -> it.getOutputPin()
+                        .getEntityName()
+                        .equals("RETURN"))
+                .filter(it -> it.getOutputLabels()
+                        .size() == 1)
+                .filter(it -> ((LabelType) it.getOutputLabels()
+                        .get(0)
+                        .eContainer()).getEntityName()
+                                .equals("GrantedRoles"))
+                .map(it -> it.getTerm())
+                .filter(AND.class::isInstance)
+                .map(AND.class::cast)
+                .filter(it -> it.getTerms()
+                        .size() == 2)
+                .filter(it -> ((LabelType) ((LabelReference) it.getTerms()
+                        .get(0)).getLabel()
+                                .eContainer()).getEntityName()
+                                        .equals("GrantedRoles"))
+                .filter(it -> ((LabelType) ((LabelReference) it.getTerms()
+                        .get(1)).getLabel()
+                                .eContainer()).getEntityName()
+                                        .equals("GrantedRoles"))
+                .toList()
+                .size());
+    }
+
+    private void testSpecificModel(String inputModel, String inputFile, String modelLocation, String webTarget,
+            Predicate<AbstractVertex<?>> constraint) {
         final var usageModelPath = Paths.get("casestudies", inputModel, inputFile + ".usagemodel")
                 .toString();
         final var allocationPath = Paths.get("casestudies", inputModel, inputFile + ".allocation")
@@ -140,89 +170,98 @@ public class PCMTest extends ConverterTest{
                 .useAllocationModel(allocationPath)
                 .useNodeCharacteristicsModel(nodeCharPath)
                 .build();
-        
+
         analysis.setLoggerLevel(Level.ALL);
 
         analysis.initializeAnalysis();
         var flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
 
-       	List<AbstractPCMVertex<?>> vertices = new ArrayList<>();
+        List<AbstractPCMVertex<?>> vertices = new ArrayList<>();
         for (AbstractTransposeFlowGraph transposeFlowGraph : flowGraph.getTransposeFlowGraphs()) {
             for (AbstractVertex<?> abstractVertex : transposeFlowGraph.getVertices()) {
-            	AbstractPCMVertex<?> v = (AbstractPCMVertex<?>) abstractVertex;
-               vertices.add(v);
+                AbstractPCMVertex<?> v = (AbstractPCMVertex<?>) abstractVertex;
+                vertices.add(v);
             }
         }
 
-        
         var complete = new PCMConverter().pcmToDFD(modelLocation, usageModelPath, allocationPath, nodeCharPath, Activator.class);
 
         var dfdConverter = new DataFlowDiagramConverter();
         List<Predicate<? super AbstractVertex<?>>> constraints = new ArrayList<>();
         constraints.add(constraint);
-        var web = dfdConverter.dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinder(complete, constraints, DFDSimpleTransposeFlowGraphFinder.class); //Replace null with simpleFinder once Analysis PR merged
+        var web = dfdConverter.dfdToWebAndAnalyzeAndAnnotateWithCustomTFGFinder(complete, constraints, DFDSimpleTransposeFlowGraphFinder.class); // Replace
+                                                                                                                                                 // null
+                                                                                                                                                 // with
+                                                                                                                                                 // simpleFinder
+                                                                                                                                                 // once
+                                                                                                                                                 // Analysis
+                                                                                                                                                 // PR
+                                                                                                                                                 // merged
         dfdConverter.storeWeb(web, webTarget);
 
         var dfd = complete.dataFlowDiagram();
         var dd = complete.dataDictionary();
-        
 
-        assertEquals(dfd.getNodes().size(), vertices.size());
-        
+        assertEquals(dfd.getNodes()
+                .size(), vertices.size());
+
         if (constraint != null) {
-        	DFDSimpleTransposeFlowGraphFinder dfdTransposeFlowGraphFinder = new DFDSimpleTransposeFlowGraphFinder(dd, dfd);
-            var dfdTFGCollection = dfdTransposeFlowGraphFinder.findTransposeFlowGraphs().
-            		stream().map(it -> {return it.evaluate();}
-            ).toList();
-	        List<String> nodeIds = new ArrayList<>();
-	        for (Node node : dfd.getNodes()) {
-	            nodeIds.add(node.getId());
-	        }        
-       
-        	List<AbstractVertex<?>> results = flowGraph.getTransposeFlowGraphs()
+            DFDSimpleTransposeFlowGraphFinder dfdTransposeFlowGraphFinder = new DFDSimpleTransposeFlowGraphFinder(dd, dfd);
+            var dfdTFGCollection = dfdTransposeFlowGraphFinder.findTransposeFlowGraphs()
+                    .stream()
+                    .map(it -> {
+                        return it.evaluate();
+                    })
+                    .toList();
+            List<String> nodeIds = new ArrayList<>();
+            for (Node node : dfd.getNodes()) {
+                nodeIds.add(node.getId());
+            }
+
+            List<AbstractVertex<?>> results = flowGraph.getTransposeFlowGraphs()
                     .stream()
                     .map(it -> analysis.queryDataFlow(it, constraint))
                     .flatMap(Collection::stream)
                     .collect(Collectors.toList());
-        	
-    	
-        	DFDConfidentialityAnalysis dfdAnalysis = new DFDConfidentialityAnalysis(null, null, TEST_JSONS);
-        	List<AbstractVertex<?>> dfdResults = dfdTFGCollection
-                .stream()
-                .map(it -> dfdAnalysis.queryDataFlow(it, constraint))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-        	
-        	assertEquals(results.size(), dfdResults.size());
+
+            DFDConfidentialityAnalysis dfdAnalysis = new DFDConfidentialityAnalysis(null, null, TEST_JSONS);
+            List<AbstractVertex<?>> dfdResults = dfdTFGCollection.stream()
+                    .map(it -> dfdAnalysis.queryDataFlow(it, constraint))
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+
+            assertEquals(results.size(), dfdResults.size());
             checkTFGs(flowGraph, dfdTFGCollection);
         }
-          
+
         checkLabels(dd, flowGraph);
         checkIDPreserving(flowGraph, dfd);
         checkNames(flowGraph, dfd);
     }
-    
+
     private void checkIDPreserving(FlowGraphCollection pcmFlowGraphs, DataFlowDiagram dfd) {
-    	List<String> ids = pcmFlowGraphs.getTransposeFlowGraphs().stream()
-    			.map(AbstractTransposeFlowGraph::getVertices)
-    			.flatMap(List::stream)
-    			.filter(it -> it instanceof AbstractPCMVertex<?>)
-    			.map(it -> (AbstractPCMVertex<?>) it)
-    			.map(it -> it.getReferencedElement().getId())
-    			.toList();
-    	List<Node> nodes = dfd.getNodes();
-    	for (Node node : nodes) {
-    		String dfdId = node.getId();
-    		if (ids.contains(dfdId)) {
-    			continue;
-    		}
-    		int suffixIndex = dfdId.lastIndexOf('_');
-    		String strippedId = dfdId.substring(0, suffixIndex);
-    		assertTrue(ids.contains(strippedId), "Could not find PCM Vertex with ID: " + dfdId + " / " + strippedId);
-    	}
+        List<String> ids = pcmFlowGraphs.getTransposeFlowGraphs()
+                .stream()
+                .map(AbstractTransposeFlowGraph::getVertices)
+                .flatMap(List::stream)
+                .filter(it -> it instanceof AbstractPCMVertex<?>)
+                .map(it -> (AbstractPCMVertex<?>) it)
+                .map(it -> it.getReferencedElement()
+                        .getId())
+                .toList();
+        List<Node> nodes = dfd.getNodes();
+        for (Node node : nodes) {
+            String dfdId = node.getId();
+            if (ids.contains(dfdId)) {
+                continue;
+            }
+            int suffixIndex = dfdId.lastIndexOf('_');
+            String strippedId = dfdId.substring(0, suffixIndex);
+            assertTrue(ids.contains(strippedId), "Could not find PCM Vertex with ID: " + dfdId + " / " + strippedId);
+        }
     }
-        
+
     private void checkNames(FlowGraphCollection pcmFlowGraphs, DataFlowDiagram dfd) {
         var vertices = pcmFlowGraphs.getTransposeFlowGraphs()
                 .stream()
@@ -235,55 +274,61 @@ public class PCMTest extends ConverterTest{
         Map<String, String> nameMapping = new HashMap<>();
 
         for (var vertex : vertices) {
-			nameMapping.putIfAbsent(vertex.getReferencedElement().getId(),
-						vertex.getReferencedElement().getEntityName());
+            nameMapping.putIfAbsent(vertex.getReferencedElement()
+                    .getId(),
+                    vertex.getReferencedElement()
+                            .getEntityName());
         }
-        
-    	List<Node> nodes = dfd.getNodes();
-    	for (Node node : nodes) {
-    		String dfdId = node.getId();
-			String nodeNameStripped = node.getEntityName().replace("Calling ", "").replace("Returning ", "");
-    		if (nameMapping.containsKey(dfdId)) {
-    			if (nameMapping.get(dfdId).equals("aName")) {
-    				continue;
-    			}
-    			assertEquals(nameMapping.get(dfdId), nodeNameStripped);
-    			continue;
-    		}
-    		int suffixIndex = dfdId.lastIndexOf('_');
-    		String strippedId = dfdId.substring(0, suffixIndex);
-    		
-    		if (!nameMapping.containsKey(strippedId)) {
-    			fail("Could not find PCM Vertex with the transformed DFD IDs: " + dfdId + " / " + strippedId);
-    		}
-			if (nameMapping.get(strippedId).equals("aName")) {
-				continue;
-			}
+
+        List<Node> nodes = dfd.getNodes();
+        for (Node node : nodes) {
+            String dfdId = node.getId();
+            String nodeNameStripped = node.getEntityName()
+                    .replace("Calling ", "")
+                    .replace("Returning ", "");
+            if (nameMapping.containsKey(dfdId)) {
+                if (nameMapping.get(dfdId)
+                        .equals("aName")) {
+                    continue;
+                }
+                assertEquals(nameMapping.get(dfdId), nodeNameStripped);
+                continue;
+            }
+            int suffixIndex = dfdId.lastIndexOf('_');
+            String strippedId = dfdId.substring(0, suffixIndex);
+
+            if (!nameMapping.containsKey(strippedId)) {
+                fail("Could not find PCM Vertex with the transformed DFD IDs: " + dfdId + " / " + strippedId);
+            }
+            if (nameMapping.get(strippedId)
+                    .equals("aName")) {
+                continue;
+            }
             assertEquals(nodeNameStripped, nameMapping.get(strippedId), "Could not find PCM Vertex with ID: " + dfdId + " / " + strippedId);
-    	}
+        }
     }
-    
+
     private void checkTFGs(FlowGraphCollection pcmFlowGraphs, List<AbstractTransposeFlowGraph> dfdFlowGraphs) {
-    	assertEquals(pcmFlowGraphs.getTransposeFlowGraphs().size(), dfdFlowGraphs.size());
+        assertEquals(pcmFlowGraphs.getTransposeFlowGraphs()
+                .size(), dfdFlowGraphs.size());
     }
-        
+
     private void checkLabels(DataDictionary dd, FlowGraphCollection flowGraph) {
-       Set<CharacteristicValue> values = new HashSet<>();
+        Set<CharacteristicValue> values = new HashSet<>();
         for (var pfg : flowGraph.getTransposeFlowGraphs()) {
             for (var vertex : pfg.getVertices()) {
                 for (var nodeChar : vertex.getAllVertexCharacteristics()) {
-                	values.add(nodeChar);
+                    values.add(nodeChar);
                 }
                 for (var dataChar : vertex.getAllIncomingDataCharacteristics()) {
-                	for (var charValue : dataChar.getAllCharacteristics()) {
-                		values.add(charValue);
-                	}
+                    for (var charValue : dataChar.getAllCharacteristics()) {
+                        values.add(charValue);
+                    }
                 }
             }
         }
 
-        List<String> labelsPCM = values
-                .stream()
+        List<String> labelsPCM = values.stream()
                 .map(c -> c.getTypeName() + "." + c.getValueName())
                 .collect(Collectors.toList());
         List<String> labelsDFD = new ArrayList<>();
@@ -306,7 +351,7 @@ public class PCMTest extends ConverterTest{
 
         assertEquals(labelsPCM, labelsDFD);
     }
-    
+
     private boolean travelPlannerCondition(AbstractVertex<?> node) {
         List<String> assignedRoles = node.getVertexCharacteristics("AssignedRoles")
                 .stream()
@@ -314,7 +359,6 @@ public class PCMTest extends ConverterTest{
                 .toList();
         Collection<List<CharacteristicValue>> grantedRoles = node.getDataCharacteristicMap("GrantedRoles")
                 .values();
-
 
         for (List<CharacteristicValue> dataFlowCharacteristics : grantedRoles) {
             if (!dataFlowCharacteristics.isEmpty() && dataFlowCharacteristics.stream()
@@ -325,73 +369,57 @@ public class PCMTest extends ConverterTest{
             }
         }
         return false;
-    }     
-    
-    private boolean maasCondition(AbstractVertex<?> vertex) {        
+    }
+
+    private boolean maasCondition(AbstractVertex<?> vertex) {
         var nodeLabels = retrieveNodeLabels(vertex);
         var dataLabels = retrieveDataLabels(vertex);
         var dataLabelTypes = retrieveDataLabelsTypes(vertex);
 
-        if ((!dataLabels.contains("Encrypted") || dataLabels.contains("FineGranular")) &&
-    		dataLabels.contains("Customer") &&
-    		(dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData")) &&
-    		!nodeLabels.contains("Customer")) 
-    		return true;
-            
+        if ((!dataLabels.contains("Encrypted") || dataLabels.contains("FineGranular")) && dataLabels.contains("Customer")
+                && (dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData")) && !nodeLabels.contains("Customer"))
+            return true;
 
-        // Constraint 2: Ticket inspectors must not be able to trace past trips of customers c        
-		if (dataLabels.contains("Vehicle") &&
-    		dataLabels.contains("VehicleData") &&
-    		dataLabels.contains("Customer") &&
-    		dataLabels.contains("TripData") &&
-    		nodeLabels.contains("Inspector"))
-			return true;
-         
+        // Constraint 2: Ticket inspectors must not be able to trace past trips of customers c
+        if (dataLabels.contains("Vehicle") && dataLabels.contains("VehicleData") && dataLabels.contains("Customer") && dataLabels.contains("TripData")
+                && nodeLabels.contains("Inspector"))
+            return true;
 
         // Constraint 3: No granular information about individual trips of customer must be visible to the company
-        
-		if (dataLabels.contains("FineGranular") &&
-			dataLabels.contains("Customer") &&
-			(dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData")) &&
-			nodeLabels.contains("MobilityProvider"))
-			return true;
-            
 
-        
-        if (dataLabels.contains("FineGranular") &&
-    		dataLabels.contains("Customer") &&
-    		dataLabels.contains("TripData") &&
-    		(nodeLabels.contains("SupportStaff") || nodeLabels.contains("BillingStaff") 
-				|| nodeLabels.contains("AnalysisStaff") || nodeLabels.contains("Administrators")))
-    		return true;   
+        if (dataLabels.contains("FineGranular") && dataLabels.contains("Customer")
+                && (dataLabels.contains("STS") || dataLabels.contains("LTS") || dataLabels.contains("TripData"))
+                && nodeLabels.contains("MobilityProvider"))
+            return true;
 
-        
+        if (dataLabels.contains("FineGranular") && dataLabels.contains("Customer") && dataLabels.contains("TripData")
+                && (nodeLabels.contains("SupportStaff") || nodeLabels.contains("BillingStaff") || nodeLabels.contains("AnalysisStaff")
+                        || nodeLabels.contains("Administrators")))
+            return true;
 
-        return 	dataLabelTypes.contains("writeActions") &&
-        		nodeLabels.contains("Write");
-           
-    
-    }   
+        return dataLabelTypes.contains("writeActions") && nodeLabels.contains("Write");
 
-	private List<String> retrieveNodeLabels(AbstractVertex<?> vertex) {
-	    return vertex.getAllVertexCharacteristics()
-	            .stream()
-	            .map(CharacteristicValue.class::cast)
-	            .map(CharacteristicValue::getValueName)
-	            .toList();
-	}
+    }
 
-	private List<String> retrieveDataLabels(AbstractVertex<?> vertex) {
-	    return vertex.getAllDataCharacteristics()
-	            .stream()
-	            .map(DataCharacteristic::getAllCharacteristics)
-	            .flatMap(List::stream)
-	            .map(CharacteristicValue.class::cast)
-	            .map(CharacteristicValue::getValueName)
-	            .toList();
-	}
-	
-	private List<String> retrieveDataLabelsTypes(AbstractVertex<?> vertex) {
+    private List<String> retrieveNodeLabels(AbstractVertex<?> vertex) {
+        return vertex.getAllVertexCharacteristics()
+                .stream()
+                .map(CharacteristicValue.class::cast)
+                .map(CharacteristicValue::getValueName)
+                .toList();
+    }
+
+    private List<String> retrieveDataLabels(AbstractVertex<?> vertex) {
+        return vertex.getAllDataCharacteristics()
+                .stream()
+                .map(DataCharacteristic::getAllCharacteristics)
+                .flatMap(List::stream)
+                .map(CharacteristicValue.class::cast)
+                .map(CharacteristicValue::getValueName)
+                .toList();
+    }
+
+    private List<String> retrieveDataLabelsTypes(AbstractVertex<?> vertex) {
         return vertex.getAllDataCharacteristics()
                 .stream()
                 .map(DataCharacteristic::getAllCharacteristics)

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/TUHHPipeline.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/TUHHPipeline.java
@@ -1,29 +1,25 @@
 package org.dataflowanalysis.converter.tests;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import static java.util.Map.entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.HashSet;
-
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.converter.MicroSecEndConverter;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TUHHPipeline {
 
@@ -32,30 +28,17 @@ public class TUHHPipeline {
 
     public static final List<Integer> OUT_OF_SCOPE_VARIANTS = List.of(13, 14, 15, 16, 17);
 
-    public static final Map<String, List<Integer>> FAULTY_VARIANTS = Map.ofEntries(
-            entry("callistaenterprise", List.of(4)),
-            entry("ewolff", List.of(3, 6)),
-            entry("fernandoabcampos", List.of(3, 6)),
-            entry("jferrater", List.of(1, 4)),
-            entry("mdeket", List.of(3, 6)),
-            entry("mudigal-technologies", List.of(3, 6)),
-            entry("rohitghatol", List.of(11)),
-            entry("spring-petclinic", List.of(4)),
-            entry("georgwittberger", List.of(9)));
+    public static final Map<String, List<Integer>> FAULTY_VARIANTS = Map.ofEntries(entry("callistaenterprise", List.of(4)),
+            entry("ewolff", List.of(3, 6)), entry("fernandoabcampos", List.of(3, 6)), entry("jferrater", List.of(1, 4)),
+            entry("mdeket", List.of(3, 6)), entry("mudigal-technologies", List.of(3, 6)), entry("rohitghatol", List.of(11)),
+            entry("spring-petclinic", List.of(4)), entry("georgwittberger", List.of(9)));
 
-    public static final Map<String, List<Integer>> CYCLIC_SINK_VARIANTS = Map.ofEntries(
-            entry("anilallewar", List.of(10)),
-            entry("ewolff", List.of(0, 2, 4, 7, 8, 11)),
-            entry("ewolff-kafka", List.of(10, 11, 12)),
-            entry("jferrater", List.of(10, 11, 12)),
-            entry("mdeket", List.of(0, 2, 4, 7, 8, 9, 10, 11, 12)),
-            entry("mudigal-technologies", List.of(10, 12)),
-            entry("piomin", List.of(0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 17, 18)),
-            entry("rohitghatol", List.of(0, 6, 7, 8, 9)),
-            entry("shabbirdwd53", List.of(0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 17, 18)),
-            entry("spring-petclinic", List.of(10, 11, 12)),
-            entry("yidongnan", List.of(10, 11, 12)),
-            entry("fernandoabcampos", List.of(0, 1, 2, 4, 5, 7, 8, 9, 10, 11, 12)));
+    public static final Map<String, List<Integer>> CYCLIC_SINK_VARIANTS = Map.ofEntries(entry("anilallewar", List.of(10)),
+            entry("ewolff", List.of(0, 2, 4, 7, 8, 11)), entry("ewolff-kafka", List.of(10, 11, 12)), entry("jferrater", List.of(10, 11, 12)),
+            entry("mdeket", List.of(0, 2, 4, 7, 8, 9, 10, 11, 12)), entry("mudigal-technologies", List.of(10, 12)),
+            entry("piomin", List.of(0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 17, 18)), entry("rohitghatol", List.of(0, 6, 7, 8, 9)),
+            entry("shabbirdwd53", List.of(0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 17, 18)), entry("spring-petclinic", List.of(10, 11, 12)),
+            entry("yidongnan", List.of(10, 11, 12)), entry("fernandoabcampos", List.of(0, 1, 2, 4, 5, 7, 8, 9, 10, 11, 12)));
 
     @Disabled
     @Test

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/WebEditorTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/WebEditorTest.java
@@ -45,14 +45,13 @@ public class WebEditorTest extends ConverterTest {
         ObjectMapper objectMapper = new ObjectMapper();
         File file = new File(minimalWebDFD);
         WebEditorDfd webBefore = objectMapper.readValue(file, WebEditorDfd.class);
-        
-        webAfter.constraints().addAll(webBefore.constraints());
+
+        webAfter.constraints()
+                .addAll(webBefore.constraints());
 
         webBefore.sort();
         webAfter.sort();
-        
-        
-        
+
         assertEquals(webBefore, webAfter);
 
         checkBehaviorAndPinNames(dfdBefore);
@@ -110,7 +109,6 @@ public class WebEditorTest extends ConverterTest {
         cleanup(tempWebDFD);
     }
 
-    
     private void checkBehaviorAndPinNames(DataFlowDiagramAndDictionary dfd) {
         for (Node node : dfd.dataFlowDiagram()
                 .getNodes()) {


### PR DESCRIPTION
This PR enforces the formatting pipeline contained in the project.
A new workflow step is included that runs mvn spotless:check to ensure adhesion to the formatting style.

Code can be formatted by importing the config (formatter.xml) into eclipse, or by running mvn spotless:apply
