### PR TITLE
Hotfix: Web Assignment spaces

### DIFF
--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
@@ -251,21 +251,21 @@ public class WebEditorConverter extends Converter {
         for (String behaviorString : behaviorStrings) {
             AbstractAssignment abstractAssignment;
             try {
-                if (behaviorString.startsWith("forward")) {
+            	if (behaviorString.startsWith("forward")) {
                     var assignment = ddFactory.createForwardingAssignment();
-                    var inPins = getInPinsFromString(behaviorString.split(" ")[1], node, dfd);
+                    var inPins = getInPinsFromString(behaviorString.replaceFirst("forward ", "").trim(), node, dfd);
                     assignment.getInputPins()
                             .addAll(inPins);
                     abstractAssignment = assignment;
                 } else if (behaviorString.startsWith("set")) {
                     var assignment = ddFactory.createSetAssignment();
-                    var outLabels = getLabelFromString(behaviorString.split(" ")[1], dd);
+                    var outLabels = getLabelFromString(behaviorString.replaceFirst("set ", "").trim(), dd);
                     assignment.getOutputLabels()
                             .addAll(outLabels);
                     abstractAssignment = assignment;
                 } else if (behaviorString.startsWith("unset")) {
                     var assignment = ddFactory.createUnsetAssignment();
-                    var outLabels = getLabelFromString(behaviorString.split(" ")[1], dd);
+                    var outLabels = getLabelFromString(behaviorString.replaceFirst("unset ", "").trim(), dd);
                     assignment.getOutputLabels()
                             .addAll(outLabels);
                     abstractAssignment = assignment;

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
@@ -251,21 +251,24 @@ public class WebEditorConverter extends Converter {
         for (String behaviorString : behaviorStrings) {
             AbstractAssignment abstractAssignment;
             try {
-            	if (behaviorString.startsWith("forward")) {
+                if (behaviorString.startsWith("forward")) {
                     var assignment = ddFactory.createForwardingAssignment();
-                    var inPins = getInPinsFromString(behaviorString.replaceFirst("forward ", "").trim(), node, dfd);
+                    var inPins = getInPinsFromString(behaviorString.replaceFirst("forward ", "")
+                    		.trim(), node, dfd);
                     assignment.getInputPins()
                             .addAll(inPins);
                     abstractAssignment = assignment;
                 } else if (behaviorString.startsWith("set")) {
                     var assignment = ddFactory.createSetAssignment();
-                    var outLabels = getLabelFromString(behaviorString.replaceFirst("set ", "").trim(), dd);
+                    var outLabels = getLabelFromString(behaviorString.replaceFirst("set ", "")
+                    		.trim(), dd);
                     assignment.getOutputLabels()
                             .addAll(outLabels);
                     abstractAssignment = assignment;
                 } else if (behaviorString.startsWith("unset")) {
                     var assignment = ddFactory.createUnsetAssignment();
-                    var outLabels = getLabelFromString(behaviorString.replaceFirst("unset ", "").trim(), dd);
+                    var outLabels = getLabelFromString(behaviorString.replaceFirst("unset ", "")
+                    		.trim(), dd);
                     assignment.getOutputLabels()
                             .addAll(outLabels);
                     abstractAssignment = assignment;

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/WebEditorConverter.java
@@ -254,21 +254,21 @@ public class WebEditorConverter extends Converter {
                 if (behaviorString.startsWith("forward")) {
                     var assignment = ddFactory.createForwardingAssignment();
                     var inPins = getInPinsFromString(behaviorString.replaceFirst("forward ", "")
-                    		.trim(), node, dfd);
+                            .trim(), node, dfd);
                     assignment.getInputPins()
                             .addAll(inPins);
                     abstractAssignment = assignment;
                 } else if (behaviorString.startsWith("set")) {
                     var assignment = ddFactory.createSetAssignment();
                     var outLabels = getLabelFromString(behaviorString.replaceFirst("set ", "")
-                    		.trim(), dd);
+                            .trim(), dd);
                     assignment.getOutputLabels()
                             .addAll(outLabels);
                     abstractAssignment = assignment;
                 } else if (behaviorString.startsWith("unset")) {
                     var assignment = ddFactory.createUnsetAssignment();
                     var outLabels = getLabelFromString(behaviorString.replaceFirst("unset ", "")
-                    		.trim(), dd);
+                            .trim(), dd);
                     assignment.getOutputLabels()
                             .addAll(outLabels);
                     abstractAssignment = assignment;


### PR DESCRIPTION
If you use spaces to seperate the Pins/Labels for Forwarding and Set/Unset Assignments the elements behind the space are ignored. This fixes this.