### PR TITLE
Testing framework adjustments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/ConverterChain.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/ConverterChain.java
@@ -15,14 +15,14 @@ public class ConverterChain extends Converter {
      * @param converters List of at least one converter that are sequentially run
      */
     public ConverterChain(List<Converter> converters) {
-        if (converters.isEmpty()) {
-            throw new IllegalArgumentException("Must provide at least one converter");
-        }
         this.converters = converters;
     }
 
     @Override
     public PersistableConverterModel convert(ConverterModel input) {
+        if (converters.isEmpty()) {
+            return (PersistableConverterModel) input;
+        }
         PersistableConverterModel current = this.converters.get(0)
                 .convert(input);
         for (int i = 1; i < this.converters.size(); i++) {

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/pcm2dfd/PCM2DFDConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/pcm2dfd/PCM2DFDConverter.java
@@ -309,7 +309,7 @@ public class PCM2DFDConverter extends Converter {
         flow.setSourceNode(sourceNode);
         flow.setDestinationPin(inPin);
         flow.setSourcePin(outPin);
-        flow.setEntityName("");
+        flow.setEntityName("~");
         dataFlowDiagram.getFlows()
                 .add(flow);
 

--- a/tests/org.dataflowanalysis.converter.tests/.classpath
+++ b/tests/org.dataflowanalysis.converter.tests/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>
 			<attribute name="test" value="true"/>

--- a/tests/org.dataflowanalysis.converter.tests/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.converter.tests/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.dataflowanalysis.converter,
  org.dataflowanalysis.analysis,
  org.dataflowanalysis.analysis.pcm,
  org.dataflowanalysis.analysis.dfd,
- org.dataflowanalysis.examplemodels
+ org.dataflowanalysis.examplemodels,
+ org.eclipse.core.runtime
 Automatic-Module-Name: org.dataflowanalysis.converter.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/PCMTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/PCMTest.java
@@ -433,9 +433,8 @@ public class PCMTest extends ConverterTest {
     }
 
     private static Stream<Arguments> getPCMModels() {
-        return Stream.of(Arguments.of(TEST_MODELS, "scenarios/pcm/CoCarNextGen/AudiA6C8.usagemodel",
-                "scenarios/pcm/CoCarNextGen/AudiA6C8.allocation", "scenarios/pcm/CoCarNextGen/AudiA6C8.nodecharacteristics",
-                Activator.class));
+        return Stream.of(Arguments.of(TEST_MODELS, "scenarios/pcm/CoCarNextGen/AudiA6C8.usagemodel", "scenarios/pcm/CoCarNextGen/AudiA6C8.allocation",
+                "scenarios/pcm/CoCarNextGen/AudiA6C8.nodecharacteristics", Activator.class));
     }
 
     @ParameterizedTest

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/PCMTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/PCMTest.java
@@ -56,7 +56,7 @@ public class PCMTest extends ConverterTest {
     @Test
     @DisplayName("Test PCM2DFD MaaS")
     public void maasToDfd() {
-        testSpecificModel("MaaS_Ticket_System_base", "MaaS", TEST_MODELS, "maas.json", this::maasCondition);
+        testSpecificModel("MaaSTicketSystem", "MaaS", TEST_MODELS, "maas.json", this::maasCondition);
     }
 
     @Test
@@ -68,11 +68,11 @@ public class PCMTest extends ConverterTest {
     @Test
     @DisplayName("Test PCM2DFD TravelPlanner Behavior")
     public void testTravelPlannerBehavior() {
-        final var usageModelPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.usagemodel")
+        final var usageModelPath = Paths.get("scenarios", "pcm", "TravelPlanner", "travelPlanner.usagemodel")
                 .toString();
-        final var allocationPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.allocation")
+        final var allocationPath = Paths.get("scenarios", "pcm", "TravelPlanner", "travelPlanner.allocation")
                 .toString();
-        final var nodeCharPath = Paths.get("casestudies", "TravelPlanner", "travelPlanner.nodecharacteristics")
+        final var nodeCharPath = Paths.get("scenarios", "pcm", "TravelPlanner", "travelPlanner.nodecharacteristics")
                 .toString();
 
         DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
@@ -163,11 +163,11 @@ public class PCMTest extends ConverterTest {
 
     private void testSpecificModel(String inputModel, String inputFile, String modelLocation, String webTarget,
             Predicate<AbstractVertex<?>> constraint) {
-        final var usageModelPath = Paths.get("casestudies", inputModel, inputFile + ".usagemodel")
+        final var usageModelPath = Paths.get("scenarios", "pcm", inputModel, inputFile + ".usagemodel")
                 .toString();
-        final var allocationPath = Paths.get("casestudies", inputModel, inputFile + ".allocation")
+        final var allocationPath = Paths.get("scenarios", "pcm", inputModel, inputFile + ".allocation")
                 .toString();
-        final var nodeCharPath = Paths.get("casestudies", inputModel, inputFile + ".nodecharacteristics")
+        final var nodeCharPath = Paths.get("scenarios", "pcm", inputModel, inputFile + ".nodecharacteristics")
                 .toString();
 
         DataFlowConfidentialityAnalysis analysis = new PCMDataFlowConfidentialityAnalysisBuilder().standalone()
@@ -433,8 +433,8 @@ public class PCMTest extends ConverterTest {
     }
 
     private static Stream<Arguments> getPCMModels() {
-        return Stream.of(Arguments.of(TEST_MODELS, "casestudies/CoCarNextGen_Base/AudiA6C8_base.usagemodel",
-                "casestudies/CoCarNextGen_Base/AudiA6C8_base.allocation", "casestudies/CoCarNextGen_Base/AudiA6C8_base.nodecharacteristics",
+        return Stream.of(Arguments.of(TEST_MODELS, "scenarios/pcm/CoCarNextGen/AudiA6C8.usagemodel",
+                "scenarios/pcm/CoCarNextGen/AudiA6C8.allocation", "scenarios/pcm/CoCarNextGen/AudiA6C8.nodecharacteristics",
                 Activator.class));
     }
 


### PR DESCRIPTION
> [!warning]
> This PR depends on #32 and https://github.com/DataFlowAnalysis/DataFlowAnalysis/pull/260

This PR uses the new paths introduced by the testing framework in the example models. Additionally, some fixes in the analysis, required a small change in the PCM2DFD Converter (namely creating flows to preserve control flows with `~` as a name instead of an empty name